### PR TITLE
Revert "Use the auth_handler on eap-success. Also fixes an error with logoff."

### DIFF
--- a/chewie/chewie.py
+++ b/chewie/chewie.py
@@ -30,15 +30,12 @@ class Chewie(object):
     EAP_ADDRESS = MacAddress.from_string("01:80:c2:00:00:03")
     RADIUS_UDP_PORT = 1812
 
-    def __init__(self, interface_name, logger=None,
-                 auth_handler=None, failure_handler=None, logoff_handler=None,
+    def __init__(self, interface_name, credentials, logger=None, auth_handler=None,
                  group_address=None, radius_server_ip=None):
         self.interface_name = interface_name
+        self.credentials = credentials
         self.logger = logger
         self.auth_handler = auth_handler
-        self.failure_handler = failure_handler
-        self.logoff_handler = logoff_handler
-
         self.group_address = group_address
         if not group_address:
             self.group_address = self.EAP_ADDRESS
@@ -88,14 +85,6 @@ class Chewie(object):
     def auth_success(self, src_mac):
         if self.auth_handler:
             self.auth_handler(src_mac, self.group_address)
-
-    def auth_failure(self, src_mac):
-        if self.failure_handler:
-            self.failure_handler(src_mac)
-
-    def auth_logoff(self, src_mac):
-        if self.logoff_handler:
-            self.logoff_handler(src_mac)
 
     def send_eap_messages(self):
         try:
@@ -227,9 +216,8 @@ class Chewie(object):
     def get_state_machine(self, src_mac):
         sm = self.state_machines.get(src_mac, None)
         if not sm:
-            sm = FullEAPStateMachine(self.eap_output_messages, self.radius_output_messages, src_mac,
-                                     self.timer_scheduler, self.auth_success,
-                                     self.auth_failure, self.auth_logoff)
+            sm = FullEAPStateMachine(self.eap_output_messages, self.radius_output_messages,
+                                     src_mac, self.timer_scheduler)
             sm.eapRestart = True
             # TODO what if port is not actually enabled, but then how did they auth?
             sm.portEnabled = True

--- a/chewie/ethernet_packet.py
+++ b/chewie/ethernet_packet.py
@@ -3,7 +3,6 @@ from .mac_address import MacAddress
 
 ETHERNET_HEADER_LENGTH = 6 + 6 + 2
 
-
 class EthernetPacket(object):
     def __init__(self, dst_mac, src_mac, ethertype, data):
         self.dst_mac = dst_mac
@@ -13,8 +12,7 @@ class EthernetPacket(object):
 
     @classmethod
     def parse(cls, packed_message):
-        dst_mac, src_mac, ethertype = struct.unpack("!6s6sH",
-                                                    packed_message[:ETHERNET_HEADER_LENGTH])
+        dst_mac, src_mac, ethertype = struct.unpack("!6s6sH", packed_message[:ETHERNET_HEADER_LENGTH])
         data = packed_message[ETHERNET_HEADER_LENGTH:]
         return cls(MacAddress(dst_mac), MacAddress(src_mac), ethertype, data)
 

--- a/chewie/event.py
+++ b/chewie/event.py
@@ -26,7 +26,7 @@ class EventPortStatusChange(Event):
     def __init__(self, port_status):
         """
         Args:
-            port_status (bool): True if port is enabled, False otherwise.
+            status (bool): True if port is enabled, False otherwise.
         """
         self.port_status = port_status
         if port_status:

--- a/chewie/state_machine.py
+++ b/chewie/state_machine.py
@@ -1,0 +1,75 @@
+import os
+import struct
+
+from hashlib import md5
+from eventlet.queue import Queue
+from .event import EventMessageReceived
+from .message_parser import IdentityMessage, Md5ChallengeMessage, EapolStartMessage
+from .message_parser import SuccessMessage, FailureMessage
+from .eap import Eap
+
+def generate_txn_id():
+    return ord(os.urandom(1))
+
+def generate_random_bytes(num_bytes):
+    return os.urandom(num_bytes)
+
+class StateMachine:
+    def __init__(self, src_mac, auth_success=None):
+        self.src_mac = src_mac
+        self.auth_success = auth_success
+
+        self.txn_id = None
+        self.challenge = None
+        self.expected_response = None
+        # TODO - some way to query for this based on identity
+        self.password = "microphone"
+        self.state = "idle"
+        self.output_messages = Queue()
+
+        self.txn_id_method = generate_txn_id
+        self.challenge_method = generate_random_bytes
+
+    def event(self, event):
+        if isinstance(event, EventMessageReceived):
+            self.handle_message_received(event.message)
+
+    def handle_message_received(self, message):
+        if self.state == "idle":
+            self.handle_idle_message(message)
+        elif self.state == "identity request sent":
+            self.handle_identity_sent_message(message)
+        elif self.state == "challenge sent":
+            self.handle_challenge_sent_message(message)
+
+    def handle_idle_message(self, message):
+        if isinstance(message, EapolStartMessage):
+            self.txn_id = self.txn_id_method()
+            identity_request = IdentityMessage(self.src_mac, self.txn_id, Eap.REQUEST, "")
+            self.output_messages.put(identity_request)
+            self.state = "identity request sent"
+
+    def handle_identity_sent_message(self, message):
+        if isinstance(message, IdentityMessage):
+            self.challenge = self.challenge_method(16)
+            self.calculate_expected_response()
+            challenge_request = Md5ChallengeMessage(self.src_mac, self.txn_id, Eap.REQUEST, self.challenge, b"")
+            self.output_messages.put(challenge_request)
+            self.state = "challenge sent"
+
+    def handle_challenge_sent_message(self, message):
+        if isinstance(message, Md5ChallengeMessage):
+            if message.challenge == self.expected_response:
+                if self.auth_success:
+                    self.auth_success(message.src_mac)
+                message = SuccessMessage(self.src_mac, self.txn_id)
+                self.output_messages.put(message)
+                self.state = "authenticated"
+            else:
+                message = FailureMessage(self.src_mac, self.txn_id)
+                self.output_messages.put(message)
+                self.state = "idle"
+
+    def calculate_expected_response(self):
+        txn_id_string = struct.pack("B", self.txn_id)
+        self.expected_response = md5(txn_id_string + self.password.encode() + self.challenge).digest()

--- a/chewie/timer.py
+++ b/chewie/timer.py
@@ -1,0 +1,16 @@
+class Timer:
+    def __init__(self, count):
+        self.count = count
+        self.tick = None
+
+    def running(self):
+        return bool(self.tick)
+
+    def expired(self, tick):
+        return self.running() and tick > self.tick + self.count
+
+    def reset(self, tick):
+        self.tick = tick
+
+    def stop(self):
+        self.tick = None

--- a/run.py
+++ b/run.py
@@ -14,5 +14,5 @@ def auth_handler(address, group_address):
 logger = utils.get_logger("CHEWIE")
 logger.info('starting chewieeeee.')
 
-chewie = Chewie("eth1", credentials, logger, auth_handler, radius_server_ip="172.24.0.113")
+chewie = Chewie("eth1", credentials, logger, auth_handler, radius_ip="172.24.0.113")
 chewie.run()

--- a/test/test_full_state_machine.py
+++ b/test/test_full_state_machine.py
@@ -25,23 +25,13 @@ class FullStateMachineStartTestCase(unittest.TestCase):
         self.radius_output_queue = Queue()
         self.timer_scheduler = sched.scheduler(time.time, time.sleep)
         self.src_mac = MacAddress.from_string("00:12:34:56:78:90")
-        self.sm = FullEAPStateMachine(self.eap_output_queue, self.radius_output_queue, self.src_mac,
-                                      self.timer_scheduler,
-                                      self.auth_handler, self.failure_handler, self.logoff_handler)
+        self.sm = FullEAPStateMachine(self.eap_output_queue, self.radius_output_queue,
+                                      self.src_mac, self.timer_scheduler)
         self.MAX_RETRANSMITS = 3
         self.sm.MAX_RETRANS = self.MAX_RETRANSMITS
-        self.sm.DEFAULT_TIMEOUT = 0.1
+        self.sm.DEFAULT_TIMEOUT = 1
         self.sm.portEnabled = True
         self.sm.eapRestart = True
-
-    def auth_handler(self, src_mac):
-        print('Successful auth from MAC %s' % str(src_mac))
-
-    def failure_handler(self, src_mac):
-        print('failure from MAC %s' % str(src_mac))
-
-    def logoff_handler(self, src_mac):
-        print('logoff from MAC %s' % str(src_mac))
 
     def test_eap_start(self):
         # input EAPStart packet.

--- a/test/test_state_machine.py
+++ b/test/test_state_machine.py
@@ -1,0 +1,99 @@
+import unittest
+import struct
+
+from netils import build_byte_string
+from hashlib import md5
+
+from chewie.state_machine import StateMachine
+from chewie.mac_address import MacAddress
+from chewie.message_parser import IdentityMessage, Md5ChallengeMessage, EapolStartMessage
+from chewie.event import EventMessageReceived
+from chewie.eap import Eap
+
+
+def txn_id_injector():
+    return 123
+
+
+def challenge_injector(_):
+    return build_byte_string("01234567890abcdef01234567890abcdef")
+
+
+def build_state_machine(src_mac):
+    state_machine = StateMachine(src_mac)
+    state_machine.txn_id_method = txn_id_injector
+    state_machine.challenge_method = challenge_injector
+
+    return state_machine
+
+
+class StateMachineIdleTestCase(unittest.TestCase):
+    def setUp(self):
+        src_mac = MacAddress.from_string("00:aa:bb:cc:dd:ee")
+        self.state_machine = build_state_machine(src_mac)
+        self.assertEqual(self.state_machine.state, "idle")
+
+    def test_packet_received_moves_to_authing_state(self):
+        message = EapolStartMessage(MacAddress.from_string("00:12:34:56:78:90"))
+        self.state_machine.event(EventMessageReceived(message))
+        self.assertEqual(self.state_machine.state, "identity request sent")
+        self.assertEqual(self.state_machine.output_messages.qsize(), 1)
+
+
+class StateMachineIdentitySentTestCase(unittest.TestCase):
+    def setUp(self):
+        src_mac = MacAddress.from_string("00:aa:bb:cc:dd:ee")
+        self.state_machine = build_state_machine(src_mac)
+        self.assertEqual(self.state_machine.state, "idle")
+        message = EapolStartMessage(MacAddress.from_string("00:12:34:56:78:90"))
+        self.state_machine.event(EventMessageReceived(message))
+        self.assertEqual(self.state_machine.state, "identity request sent")
+        self.assertEqual(self.state_machine.output_messages.qsize(), 1)
+        self.state_machine.output_messages.get()
+
+    def test_identity_request_received_moves_to_challenge_sent(self):
+        message = IdentityMessage(MacAddress.from_string("00:12:34:56:78:90"), 1, Eap.RESPONSE, "betelgeuse")
+        self.state_machine.event(EventMessageReceived(message))
+        self.assertEqual(self.state_machine.state, "challenge sent")
+        self.assertEqual(self.state_machine.output_messages.qsize(), 1)
+
+
+class StateMachineChallengeSentTestCase(unittest.TestCase):
+    def setUp(self):
+        src_mac = MacAddress.from_string("00:aa:bb:cc:dd:ee")
+        self.state_machine = build_state_machine(src_mac)
+        self.assertEqual(self.state_machine.state, "idle")
+        message = EapolStartMessage(MacAddress.from_string("00:12:34:56:78:90"))
+        self.state_machine.event(EventMessageReceived(message))
+        self.assertEqual(self.state_machine.state, "identity request sent")
+        self.assertEqual(self.state_machine.output_messages.qsize(), 1)
+        self.state_machine.output_messages.get()
+        message = IdentityMessage(MacAddress.from_string("00:12:34:56:78:90"), 1, Eap.RESPONSE, "betelgeuse")
+        self.state_machine.event(EventMessageReceived(message))
+        self.assertEqual(self.state_machine.state, "challenge sent")
+        self.assertEqual(self.state_machine.output_messages.qsize(), 1)
+        self.state_machine.output_messages.get()
+
+    def test_correct_challenge_received_moves_to_authenticated(self):
+        txn_id = 123
+        challenge = build_byte_string("01234567890abcdef01234567890abcdef")
+        password = "microphone"
+        id_string = struct.pack("B", txn_id)
+        challenge_response = md5(id_string + password.encode() + challenge).digest()
+        message = Md5ChallengeMessage(
+            MacAddress.from_string("00:12:34:56:78:90"), self.state_machine.txn_id, Eap.RESPONSE, challenge_response, b"who cares")
+        self.state_machine.event(EventMessageReceived(message))
+        self.assertEqual(self.state_machine.state, "authenticated")
+        self.assertEqual(self.state_machine.output_messages.qsize(), 1)
+
+    def test_incorrect_challenge_received_moves_to_idle(self):
+        txn_id = 123
+        challenge = build_byte_string("01234567890abcdef01234567890abcdef")
+        password = "notmicrophone"
+        id_string = struct.pack("B", txn_id)
+        challenge_response = md5(id_string + password.encode() + challenge).digest()
+        message = Md5ChallengeMessage(
+            MacAddress.from_string("00:12:34:56:78:90"), self.state_machine.txn_id, Eap.RESPONSE, challenge_response, b"who cares")
+        self.state_machine.event(EventMessageReceived(message))
+        self.assertEqual(self.state_machine.state, "idle")
+        self.assertEqual(self.state_machine.output_messages.qsize(), 1)

--- a/test/test_timer.py
+++ b/test/test_timer.py
@@ -1,0 +1,25 @@
+import unittest
+
+from chewie.timer import Timer
+
+class TimerTestCase(unittest.TestCase):
+    def test_timer_is_off_by_default(self):
+        timer = Timer(60)
+        self.assertFalse(timer.running())
+
+    def test_timer_expires(self):
+        base_tick = 10000
+        timer_count = 60
+        timer = Timer(timer_count)
+        self.assertFalse(timer.expired(base_tick))
+        self.assertFalse(timer.expired(base_tick+timer_count-1))
+        self.assertFalse(timer.expired(base_tick+timer_count+1))
+        timer.reset(base_tick)
+        self.assertTrue(timer.running())
+        self.assertFalse(timer.expired(base_tick))
+        self.assertFalse(timer.expired(base_tick+timer_count-1))
+        self.assertTrue(timer.expired(base_tick+timer_count+1))
+        timer.stop()
+        self.assertFalse(timer.expired(base_tick))
+        self.assertFalse(timer.expired(base_tick+timer_count-1))
+        self.assertFalse(timer.expired(base_tick+timer_count+1))


### PR DESCRIPTION
Reverts faucetsdn/chewie#16

=================================== FAILURES ===================================
__________ FullStateMachineStartTestCase.test_md5_challenge_response ___________
self = <test_full_state_machine.FullStateMachineStartTestCase testMethod=test_md5_challenge_response>
    def test_md5_challenge_response(self):
>       self.test_md5_challenge_request()
test/test_full_state_machine.py:166: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
test/test_full_state_machine.py:153: in test_md5_challenge_request
    self.test_identity_response()
test/test_full_state_machine.py:149: in test_identity_response
    self.assertEqual(self.radius_output_queue.qsize(), 1)
E   AssertionError: 0 != 1
----------------------------- Captured stdout call -----------------------------
2018-08-28 20:42:42,721 - SM - 00:12:34:56:78:90 - INFO - full state machine received event
2018-08-28 20:42:42,721 - SM - 00:12:34:56:78:90 - INFO - type: <class 'chewie.message_parser.EapolStartMessage'>, message <chewie.message_parser.EapolStartMessage object at 0x7f93f5c9b048>
2018-08-28 20:42:42,722 - SM - 00:12:34:56:78:90 - INFO - Entering initialize_state
2018-08-28 20:42:42,722 - SM - 00:12:34:56:78:90 - INFO - Entering select_action_state
2018-08-28 20:42:42,722 - SM - 00:12:34:56:78:90 - INFO - Entering propose_method_state
2018-08-28 20:42:42,722 - SM - 00:12:34:56:78:90 - INFO - Entering method_request_state
2018-08-28 20:42:42,722 - SM - 00:12:34:56:78:90 - INFO - Entering send_request_state
2018-08-28 20:42:42,723 - SM - 00:12:34:56:78:90 - INFO - Entering idle_state
2018-08-28 20:42:42,723 - SM - 00:12:34:56:78:90 - INFO - end state: IDLE
2018-08-28 20:42:42,723 - SM - 00:12:34:56:78:90 - INFO - full state machine received event
2018-08-28 20:42:42,723 - SM - 00:12:34:56:78:90 - INFO - type: <class 'chewie.message_parser.IdentityMessage'>, message <chewie.message_parser.IdentityMessage object at 0x7f93f5c9bc18>
2018-08-28 20:42:42,723 - SM - 00:12:34:56:78:90 - INFO - Entering recieved_state
2018-08-28 20:42:42,723 - SM - 00:12:34:56:78:90 - DEBUG - RECEIVED- rxResp: 2, respId: 0, respMethod: IDENTITY
2018-08-28 20:42:42,724 - SM - 00:12:34:56:78:90 - DEBUG - RECIEVED- currentId: 0, currentMethod: IDENTITY, methodState: CONTINUE
2018-08-28 20:42:42,724 - SM - 00:12:34:56:78:90 - INFO - Entering integrity_check_state
2018-08-28 20:42:42,724 - SM - 00:12:34:56:78:90 - INFO - Entering method_response_state
2018-08-28 20:42:42,724 - SM - 00:12:34:56:78:90 - INFO - Entering select_action_state
2018-08-28 20:42:42,724 - SM - 00:12:34:56:78:90 - INFO - Entering initialize_passthrough_state
2018-08-28 20:42:42,724 - SM - 00:12:34:56:78:90 - INFO - Entering aaa_idle_state
2018-08-28 20:42:42,724 - SM - 00:12:34:56:78:90 - INFO - end state: AAA_IDLE
2018-08-28 20:42:42,725 - SM - 00:12:34:56:78:90 - ERROR - aaaEapResp is true. but data is false. This should never happen
----------------------------- Captured stderr call -----------------------------
eap_state_machine.py       719 ERROR    aaaEapResp is true. but data is false. This should never happen
------------------------------ Captured log call -------------------------------
eap_state_machine.py       685 INFO     full state machine received event
eap_state_machine.py       768 INFO     type: <class 'chewie.message_parser.EapolStartMessage'>, message <chewie.message_parser.EapolStartMessage object at 0x7f93f5c9b048>
utils.py                    20 INFO     Entering initialize_state
utils.py                    20 INFO     Entering select_action_state
utils.py                    20 INFO     Entering propose_method_state
utils.py                    20 INFO     Entering method_request_state
utils.py                    20 INFO     Entering send_request_state
utils.py                    20 INFO     Entering idle_state
eap_state_machine.py       698 INFO     end state: IDLE
eap_state_machine.py       685 INFO     full state machine received event
eap_state_machine.py       768 INFO     type: <class 'chewie.message_parser.IdentityMessage'>, message <chewie.message_parser.IdentityMessage object at 0x7f93f5c9bc18>
utils.py                    20 INFO     Entering recieved_state
eap_state_machine.py       556 DEBUG    RECEIVED- rxResp: 2, respId: 0, respMethod: IDENTITY
eap_state_machine.py       558 DEBUG    RECIEVED- currentId: 0, currentMethod: IDENTITY, methodState: CONTINUE
utils.py                    20 INFO     Entering integrity_check_state
utils.py                    20 INFO     Entering method_response_state
utils.py                    20 INFO     Entering select_action_state
utils.py                    20 INFO     Entering initialize_passthrough_state
utils.py                    20 INFO     Entering aaa_idle_state
eap_state_machine.py       698 INFO     end state: AAA_IDLE
eap_state_machine.py       719 ERROR    aaaEapResp is true. but data is false. This should never happen
===================== 1 failed, 59 passed in 1.65 seconds ======================