### PR TITLE
Pylint

### DIFF
--- a/chewie/auth_8021x.py
+++ b/chewie/auth_8021x.py
@@ -5,7 +5,7 @@ def hwaddr_to_string(hwaddr):
 
 AUTH_8021X_HEADER_LENGTH = 1 + 1 + 2
 
-class Auth8021x(object):
+class Auth8021x():
     def __init__(self, version, packet_type, data):
         self.version = version
         self.packet_type = packet_type

--- a/chewie/auth_8021x.py
+++ b/chewie/auth_8021x.py
@@ -1,11 +1,15 @@
 import struct
 
+
 def hwaddr_to_string(hwaddr):
     return ":".join(["%02x" % x for x in hwaddr])
 
+
 AUTH_8021X_HEADER_LENGTH = 1 + 1 + 2
 
-class Auth8021x():
+
+class Auth8021x:
+    """basically a EAPOL packet"""
     def __init__(self, version, packet_type, data):
         self.version = version
         self.packet_type = packet_type
@@ -13,11 +17,22 @@ class Auth8021x():
 
     @classmethod
     def parse(cls, packed_message):
-        version, packet_type, length = struct.unpack("!BBH", packed_message[:AUTH_8021X_HEADER_LENGTH])
+        """construct an Auth8021x from a packed_message
+        Args:
+            packed_message (bytes):
+        Returns:
+            Auth8021x
+        """
+        version, packet_type, length = struct.unpack("!BBH",
+                                                     packed_message[:AUTH_8021X_HEADER_LENGTH])
         data = packed_message[AUTH_8021X_HEADER_LENGTH:AUTH_8021X_HEADER_LENGTH+length]
         return cls(version, packet_type, data)
 
     def pack(self):
+        """Pack up the EAPOL packet to bytes.
+        Returns:
+            bytes
+        """
         header = struct.pack("!BBH", self.version, self.packet_type, len(self.data))
         return header + self.data
 

--- a/chewie/eap.py
+++ b/chewie/eap.py
@@ -6,7 +6,7 @@ EAP_TYPE_LENGTH = 1
 PARSERS = {}
 
 
-class Eap():
+class Eap:
     REQUEST = 1
     RESPONSE = 2
     SUCCESS = 3
@@ -24,8 +24,10 @@ class Eap():
     @staticmethod
     def parse(packed_message):
         code, packet_id, length = struct.unpack("!BBH", packed_message[:EAP_HEADER_LENGTH])
-        if code == Eap.REQUEST or code == Eap.RESPONSE:
-            packet_type, = struct.unpack("!B", packed_message[EAP_HEADER_LENGTH:EAP_HEADER_LENGTH+EAP_TYPE_LENGTH])
+        if code in (Eap.REQUEST, Eap.RESPONSE):
+            packet_type, = struct.unpack("!B",
+                                         packed_message[EAP_HEADER_LENGTH :
+                                                        EAP_HEADER_LENGTH + EAP_TYPE_LENGTH])
             data = packed_message[EAP_HEADER_LENGTH+EAP_TYPE_LENGTH:length]
             return PARSERS[packet_type](code, packet_id, data)
         elif code == Eap.SUCCESS:
@@ -36,7 +38,8 @@ class Eap():
 
     def pack(self, packed_body):
         header = struct.pack("!BBHB", self.code, self.packet_id,
-                             EAP_HEADER_LENGTH + EAP_TYPE_LENGTH + len(packed_body), self.PACKET_TYPE)
+                             EAP_HEADER_LENGTH + EAP_TYPE_LENGTH + len(packed_body),
+                             self.PACKET_TYPE)
         return header + packed_body
 
 
@@ -142,7 +145,8 @@ class EapLegacyNak(Eap):
         return cls(code, packet_id, desired_auth_types)
 
     def pack(self):
-        packed_legacy_nak = struct.pack("!%ds" % len(self.desired_auth_types), *self.desired_auth_types)  # pytype: disable=wrong-arg-types
+        packed_legacy_nak = struct.pack("!%ds" % len(self.desired_auth_types),
+                                        *self.desired_auth_types)  # pytype: disable=wrong-arg-types
         return super(EapLegacyNak, self).pack(packed_legacy_nak)
 
     def __repr__(self):

--- a/chewie/eap.py
+++ b/chewie/eap.py
@@ -6,7 +6,7 @@ EAP_TYPE_LENGTH = 1
 PARSERS = {}
 
 
-class Eap(object):
+class Eap():
     REQUEST = 1
     RESPONSE = 2
     SUCCESS = 3

--- a/chewie/ethernet_packet.py
+++ b/chewie/ethernet_packet.py
@@ -5,6 +5,7 @@ ETHERNET_HEADER_LENGTH = 6 + 6 + 2
 
 
 class EthernetPacket:
+    """Packet/parsers for an IEEE 802.3 Ethernet frame"""
     def __init__(self, dst_mac, src_mac, ethertype, data):
         self.dst_mac = dst_mac
         self.src_mac = src_mac
@@ -13,12 +14,22 @@ class EthernetPacket:
 
     @classmethod
     def parse(cls, packed_message):
+        """construct an EthernetPacket from a packed_message
+        Args:
+            packed_message (bytes):
+        Returns:
+            EthernetPacket
+        """
         dst_mac, src_mac, ethertype = struct.unpack("!6s6sH",
                                                     packed_message[:ETHERNET_HEADER_LENGTH])
         data = packed_message[ETHERNET_HEADER_LENGTH:]
         return cls(MacAddress(dst_mac), MacAddress(src_mac), ethertype, data)
 
     def pack(self):
+        """Pack up the ethernet packet to bytes.
+        Returns:
+            bytes
+        """
         header = struct.pack("!6s6sH", self.dst_mac.address, self.src_mac.address, self.ethertype)
         return header + self.data
 

--- a/chewie/ethernet_packet.py
+++ b/chewie/ethernet_packet.py
@@ -4,7 +4,7 @@ from chewie.mac_address import MacAddress
 ETHERNET_HEADER_LENGTH = 6 + 6 + 2
 
 
-class EthernetPacket(object):
+class EthernetPacket:
     def __init__(self, dst_mac, src_mac, ethertype, data):
         self.dst_mac = dst_mac
         self.src_mac = src_mac

--- a/chewie/event.py
+++ b/chewie/event.py
@@ -1,4 +1,8 @@
-class Event(object):
+"""Various Events used by Chewie"""
+
+
+class Event:
+    """Base event class"""
     TIMER_EXPIRED = 1
     MESSAGE_RECEIVED = 2
     SHUTDOWN = 3
@@ -7,7 +11,13 @@ class Event(object):
 
 
 class EventTimerExpired(Event):
+    """Used when a timer has expired."""
     def __init__(self, state_machine=None, sent_count=None):
+        """
+        Args:
+            state_machine: state machine that triggered the event
+            sent_count: number of packets sent at time of event creation.
+        """
         # will work but please do this properly
         self.type = self.TIMER_EXPIRED
         self.state_machine = state_machine
@@ -15,7 +25,13 @@ class EventTimerExpired(Event):
 
 
 class EventMessageReceived(Event):
+    """Message (EAP) Received. Radius Message event is a child"""
     def __init__(self, message, port_id):
+        """
+        Args:
+            message:
+            port_id: id of switch port where message was received.
+        """
         # will work but please do this properly
         self.type = self.MESSAGE_RECEIVED
         self.message = message
@@ -23,6 +39,7 @@ class EventMessageReceived(Event):
 
 
 class EventPortStatusChange(Event):
+    """Port status has changed (up/down)"""
 
     def __init__(self, port_status):
         """
@@ -37,13 +54,20 @@ class EventPortStatusChange(Event):
 
 
 class EventRadiusMessageReceived(EventMessageReceived):
+    """Radius Message Received."""
 
     def __init__(self, message, state):
+        """
+        Args:
+            message:
+            state: the RADIUS state attribute
+        """
         super().__init__(message, None)
         self.state = state
 
 
 class EventShutdown(Event):
+    """Shutdown has been signaled (is this even used?)"""
     def __init__(self):
         # will work but please do this properly
         self.type = self.SHUTDOWN

--- a/chewie/event.py
+++ b/chewie/event.py
@@ -1,5 +1,7 @@
 """Various Events used by Chewie"""
 
+# pylint: disable=too-few-public-methods
+
 
 class Event:
     """Base event class"""

--- a/chewie/mac_address.py
+++ b/chewie/mac_address.py
@@ -1,12 +1,20 @@
+"""MAC address helper"""
 from netils import build_byte_string
 
 
 class MacAddress:
+    """Class for comparing mac addresses"""
     def __init__(self, address):
         self.address = address
 
     @classmethod
     def from_string(cls, address_string):
+        """Create a MacAddress from a string
+        Args:
+            address_string (str):
+        Returns:
+            MacAddress
+        """
         address_bytes = "".join(address_string.split(":"))
         address = build_byte_string(address_bytes)
 

--- a/chewie/message_parser.py
+++ b/chewie/message_parser.py
@@ -1,3 +1,6 @@
+
+# pylint: disable=too-few-public-methods
+
 from chewie.radius import RadiusAttributesList, RadiusAccessRequest, Radius
 from chewie.radius_attributes import CallingStationId, UserName, MessageAuthenticator, EAPMessage
 from chewie.ethernet_packet import EthernetPacket
@@ -98,6 +101,7 @@ EAP_MESSAGES = {
     Eap.LEGACY_NAK: LegacyNakMessage,
     Eap.TTLS: TtlsMessage,
 }
+
 
 AUTH_8021X_MESSAGES = {
     0: "eap",

--- a/chewie/message_parser.py
+++ b/chewie/message_parser.py
@@ -5,7 +5,7 @@ from chewie.auth_8021x import Auth8021x
 from chewie.eap import Eap, EapIdentity, EapMd5Challenge, EapSuccess, EapFailure, EapLegacyNak, EapTTLS
 
 
-class EapMessage(object):
+class EapMessage:
     src_mac = None
     message_id = None
 

--- a/chewie/radius.py
+++ b/chewie/radius.py
@@ -27,7 +27,7 @@ class InvalidMessageAuthenticatorError(Exception):
     pass
 
 
-class Radius(object):
+class Radius:
     """Radius packet interface which will determin the correct RadiusPacket child class to use"""
     ACCESS_REQUEST = 1
     ACCESS_ACCEPT = 2
@@ -188,7 +188,7 @@ class RadiusAccessChallenge(RadiusPacket):
     CODE = Radius.ACCESS_CHALLENGE
 
 
-class RadiusAttributesList(object):
+class RadiusAttributesList():
     """Container class for the Radius Attribute Value Pairs"""
 
     def __init__(self, attributes):

--- a/chewie/radius_attributes.py
+++ b/chewie/radius_attributes.py
@@ -30,7 +30,7 @@ class Attribute():
         Returns:
             Attribute subclass.
         """
-        return cls(cls.DATA_TYPE(raw_data=data))
+        return cls(cls.DATA_TYPE(raw_data=data))  # pylint: disable=not-callable
 
     @classmethod
     def parse(cls, packed_value):
@@ -60,12 +60,14 @@ class Attribute():
 
 
 def register_attribute_type(cls):
+    """Decoratot to register RADIUS attribute types"""
     ATTRIBUTE_TYPES[cls.TYPE] = cls
     return cls
 
 
 @register_attribute_type
 class UserName(Attribute):
+    """User-Name https://tools.ietf.org/html/rfc2865#section-5.1"""
     TYPE = 1
     DATA_TYPE = Text
     DESCRIPTION = "User-Name"
@@ -73,6 +75,7 @@ class UserName(Attribute):
 
 @register_attribute_type
 class ServiceType(Attribute):
+    """Service-Type https://tools.ietf.org/html/rfc2865#section-5.6"""
     TYPE = 6
     DATA_TYPE = Enum
     DESCRIPTION = "Service-Type"
@@ -80,6 +83,7 @@ class ServiceType(Attribute):
 
 @register_attribute_type
 class FramedMTU(Attribute):
+    """Framed-MTU https://tools.ietf.org/html/rfc2865#section-5.12"""
     TYPE = 12
     DATA_TYPE = Integer
     DESCRIPTION = "Framed-MTU"
@@ -87,6 +91,7 @@ class FramedMTU(Attribute):
 
 @register_attribute_type
 class ReplyMessage(Attribute):
+    """Reply-Message https://tools.ietf.org/html/rfc2865#section-5.18"""
     TYPE = 18
     DATA_TYPE = Text
     DESCRIPTION = "Reply-Message"
@@ -94,6 +99,7 @@ class ReplyMessage(Attribute):
 
 @register_attribute_type
 class State(Attribute):
+    """State https://tools.ietf.org/html/rfc2865#section-5.24"""
     TYPE = 24
     DATA_TYPE = String
     DESCRIPTION = "State"
@@ -103,6 +109,7 @@ class State(Attribute):
 
 @register_attribute_type
 class VendorSpecific(Attribute):
+    """Vendor-Specific https://tools.ietf.org/html/rfc2865#section-5.26"""
     TYPE = 26
     DATA_TYPE = Vsa
     DESCRIPTION = "Vendor-Specific"
@@ -110,6 +117,7 @@ class VendorSpecific(Attribute):
 
 @register_attribute_type
 class CalledStationId(Attribute):
+    """Called-Station-Id https://tools.ietf.org/html/rfc2865#section-5.30"""
     TYPE = 30
     DATA_TYPE = Text
     DESCRIPTION = "Called-Station-Id"
@@ -117,6 +125,7 @@ class CalledStationId(Attribute):
 
 @register_attribute_type
 class CallingStationId(Attribute):
+    """Calling-Station-Id https://tools.ietf.org/html/rfc2865#section-5.31"""
     TYPE = 31
     DATA_TYPE = Text
     DESCRIPTION = "Calling-Station-Id"
@@ -124,6 +133,7 @@ class CallingStationId(Attribute):
 
 @register_attribute_type
 class AcctSessionId(Attribute):
+    """Acct-Session-id (RADIUS Accounting) https://tools.ietf.org/html/rfc2866#section-5.5"""
     TYPE = 44
     DATA_TYPE = Text
     DESCRIPTION = "Acct-Session-Id"
@@ -131,6 +141,7 @@ class AcctSessionId(Attribute):
 
 @register_attribute_type
 class NASPortType(Attribute):
+    """NAS-Port-Type https://tools.ietf.org/html/rfc2865#section-5.41"""
     TYPE = 61
     DATA_TYPE = Enum
     DESCRIPTION = "NAS-Port-Type"
@@ -138,6 +149,7 @@ class NASPortType(Attribute):
 
 @register_attribute_type
 class ConnectInfo(Attribute):
+    """ConnectInfo (RADIUS Extensions) https://tools.ietf.org/html/rfc2869#section-5.11"""
     TYPE = 77
     DATA_TYPE = Text
     DESCRIPTION = "Connect-Info"
@@ -145,6 +157,7 @@ class ConnectInfo(Attribute):
 
 @register_attribute_type
 class EAPMessage(Attribute):
+    """EAP-Message (RADIUS Extensions) https://tools.ietf.org/html/rfc2869#section-5.13"""
     TYPE = 79
     DATA_TYPE = Concat
     DESCRIPTION = "EAP-Message"
@@ -157,6 +170,7 @@ class EAPMessage(Attribute):
 
 @register_attribute_type
 class MessageAuthenticator(Attribute):
+    """Message-Authenticator (RADIUS Extensions) https://tools.ietf.org/html/rfc2869#section-5.14"""
     TYPE = 80
     DATA_TYPE = String
     DESCRIPTION = "Message-Authenticator"

--- a/chewie/radius_attributes.py
+++ b/chewie/radius_attributes.py
@@ -10,7 +10,7 @@ from chewie.radius_datatypes import Concat, Enum, Integer, String, Text, Vsa
 ATTRIBUTE_TYPES = {}
 
 
-class Attribute(object):
+class Attribute():
     """Parent class for the Attributes."""
 
     TYPE = None  # e.g. 1

--- a/chewie/radius_datatypes.py
+++ b/chewie/radius_datatypes.py
@@ -5,7 +5,7 @@ import struct
 import chewie.message_parser
 
 
-class DataType(object):
+class DataType():
     """Parent datatype class, subclass should provide implementation for abstractmethods.
     May """
     DATA_TYPE_VALUE = None

--- a/test/codecheck/min_pylint.sh
+++ b/test/codecheck/min_pylint.sh
@@ -3,7 +3,7 @@
 CHEWIEHOME=`dirname $0`"/../.."
 PYTHONPATH=$CHEWIEHOME
 
-MINRATING=6.0
+MINRATING=7.0
 
 lintfile=`mktemp`.lint
 

--- a/test/codecheck/min_pylint.sh
+++ b/test/codecheck/min_pylint.sh
@@ -3,7 +3,7 @@
 CHEWIEHOME=`dirname $0`"/../.."
 PYTHONPATH=$CHEWIEHOME
 
-MINRATING=7.0
+MINRATING=8.0
 
 lintfile=`mktemp`.lint
 

--- a/test/codecheck/min_pylint.sh
+++ b/test/codecheck/min_pylint.sh
@@ -3,7 +3,7 @@
 CHEWIEHOME=`dirname $0`"/../.."
 PYTHONPATH=$CHEWIEHOME
 
-MINRATING=5.1
+MINRATING=6.0
 
 lintfile=`mktemp`.lint
 

--- a/test/test_auth_8021x.py
+++ b/test/test_auth_8021x.py
@@ -1,6 +1,10 @@
+
+# pylint: disable=missing-docstring
+
 import unittest
 from netils import build_byte_string
 from chewie.auth_8021x import Auth8021x
+
 
 class Auth8021xTestCase(unittest.TestCase):
     def test_auth_8021x_parses(self):

--- a/test/test_eap.py
+++ b/test/test_eap.py
@@ -10,7 +10,8 @@ class EapTestCase(unittest.TestCase):
         self.assertEqual(message.identity, "")
 
     def test_eap_md5_challenge_parses(self):
-        packed_message = build_byte_string("0201002204103a535f0ee8c6b34fe714aa7dad9a0e154a6f686e2e4d63477569726b")
+        packed_message = build_byte_string(
+            "0201002204103a535f0ee8c6b34fe714aa7dad9a0e154a6f686e2e4d63477569726b")
         message = Eap.parse(packed_message)
         self.assertEqual(message.packet_id, 1)
         self.assertEqual(message.challenge, build_byte_string("3a535f0ee8c6b34fe714aa7dad9a0e15"))
@@ -23,8 +24,12 @@ class EapTestCase(unittest.TestCase):
         self.assertEqual(expected_packed_message, packed_message)
 
     def test_eap_md5_challenge_packs(self):
-        expected_packed_message = build_byte_string("0201002204103a535f0ee8c6b34fe714aa7dad9a0e154a6f686e2e4d63477569726b")
-        eap = EapMd5Challenge(Eap.RESPONSE, 1, build_byte_string("3a535f0ee8c6b34fe714aa7dad9a0e15"), b"John.McGuirk")
+        expected_packed_message = build_byte_string(
+            "0201002204103a535f0ee8c6b34fe714aa7dad9a0e154a6f686e2e4d63477569726b")
+        eap = EapMd5Challenge(Eap.RESPONSE,
+                              1,
+                              build_byte_string("3a535f0ee8c6b34fe714aa7dad9a0e15"),
+                              b"John.McGuirk")
         packed_message = eap.pack()
         self.assertEqual(expected_packed_message, packed_message)
 

--- a/test/test_eap.py
+++ b/test/test_eap.py
@@ -1,6 +1,10 @@
+
+# pylint: disable=missing-docstring
+
 import unittest
 from netils import build_byte_string
 from chewie.eap import Eap, EapIdentity, EapMd5Challenge, EapSuccess, EapFailure
+
 
 class EapTestCase(unittest.TestCase):
     def test_eap_identity_parses(self):

--- a/test/test_ethernet_packet.py
+++ b/test/test_ethernet_packet.py
@@ -1,3 +1,6 @@
+
+# pylint: disable=missing-docstring
+
 import unittest
 from netils import build_byte_string
 from chewie.ethernet_packet import EthernetPacket

--- a/test/test_ethernet_packet.py
+++ b/test/test_ethernet_packet.py
@@ -3,6 +3,7 @@ from netils import build_byte_string
 from chewie.ethernet_packet import EthernetPacket
 from chewie.mac_address import MacAddress
 
+
 class EthernetPacketTestCase(unittest.TestCase):
     def test_ethernet_packet_parses(self):
         packed_message = build_byte_string("0180c2000003001906eab88c888e0100000501010005010000")
@@ -13,7 +14,11 @@ class EthernetPacketTestCase(unittest.TestCase):
         self.assertEqual(message.data, build_byte_string("0100000501010005010000"))
 
     def test_ethernet_packet_packs(self):
-        expected_packed_message = build_byte_string("0180c2000003001906eab88c888e0100000501010005010000")
-        message = EthernetPacket(dst_mac=MacAddress.from_string("01:80:c2:00:00:03"), src_mac=MacAddress.from_string("00:19:06:ea:b8:8c"), ethertype=0x888e, data=build_byte_string("0100000501010005010000"))
+        expected_packed_message = build_byte_string(
+            "0180c2000003001906eab88c888e0100000501010005010000")
+        message = EthernetPacket(dst_mac=MacAddress.from_string("01:80:c2:00:00:03"),
+                                 src_mac=MacAddress.from_string("00:19:06:ea:b8:8c"),
+                                 ethertype=0x888e,
+                                 data=build_byte_string("0100000501010005010000"))
         packed_message = message.pack()
         self.assertEqual(expected_packed_message, packed_message)

--- a/test/test_full_state_machine.py
+++ b/test/test_full_state_machine.py
@@ -1,3 +1,6 @@
+
+# pylint: disable=missing-docstring
+
 import sched
 import time
 from queue import Queue
@@ -153,7 +156,8 @@ class FullStateMachineStartTestCase(unittest.TestCase):
         self.test_identity_response()
 
         eap_message = Md5ChallengeMessage(self.src_mac, 2, Eap.REQUEST,
-                                          build_byte_string("74d3db089b727d9cc5774599e4a32a29"), b"host1user")
+                                          build_byte_string("74d3db089b727d9cc5774599e4a32a29"),
+                                          b"host1user")
         self.sm.event(EventRadiusMessageReceived(eap_message, None))
         self.assertEqual(self.sm.currentState, self.sm.IDLE2)
 
@@ -166,7 +170,8 @@ class FullStateMachineStartTestCase(unittest.TestCase):
         self.test_md5_challenge_request()
 
         message = Md5ChallengeMessage(self.src_mac, 2, Eap.RESPONSE,
-                                      build_byte_string("3a535f0ee8c6b34fe714aa7dad9a0e15"), b"host1user")
+                                      build_byte_string("3a535f0ee8c6b34fe714aa7dad9a0e15"),
+                                      b"host1user")
         self.sm.event(EventMessageReceived(message, None))
         self.assertEqual(self.sm.currentState, self.sm.AAA_IDLE)
         self.assertEqual(self.eap_output_queue.qsize(), 2)
@@ -226,7 +231,8 @@ class FullStateMachineStartTestCase(unittest.TestCase):
         self.test_md5_challenge_request()
 
         message = Md5ChallengeMessage(self.src_mac, 222, Eap.RESPONSE,
-                                      build_byte_string("3a535f0ee8c6b34fe714aa7dad9a0e15"), b"host1user")
+                                      build_byte_string("3a535f0ee8c6b34fe714aa7dad9a0e15"),
+                                      b"host1user")
         self.sm.event(EventMessageReceived(message, None))
         self.assertEqual(self.sm.currentState, self.sm.IDLE2)
         self.assertEqual(self.eap_output_queue.qsize(), 2)

--- a/test/test_message_parser.py
+++ b/test/test_message_parser.py
@@ -1,3 +1,6 @@
+
+# pylint: disable=missing-docstring
+
 import unittest
 from netils import build_byte_string
 from chewie.message_parser import MessageParser, MessagePacker, IdentityMessage, Md5ChallengeMessage, TtlsMessage, \
@@ -38,7 +41,7 @@ class MessageParserTestCase(unittest.TestCase):
 
     def test_md5_challenge_response_message_parses(self):
         packed_message = build_byte_string(
-            "0180c2000003001422e9545e888e010000220201002204103a535f0ee8c6b34fe714aa7dad9a0e154a6f686e2e4d63477569726b")
+            "0180c2000003001422e9545e888e010000220201002204103a535f0ee8c6b34fe714aa7dad9a0e154a6f686e2e4d63477569726b")  # pylint: disable=line-too-long
         message = MessageParser.ethernet_parse(packed_message)[0]
         self.assertEqual(MacAddress.from_string("00:14:22:e9:54:5e"), message.src_mac)
         self.assertEqual(1, message.message_id)
@@ -81,7 +84,8 @@ class MessageParserTestCase(unittest.TestCase):
         self.assertEqual(expected_packed_message, packed_message)
 
     def test_md5_challenge_response_message_packs(self):
-        expected_packed_message = build_byte_string("0180c2000003001422e9545e888e010000220201002204103a535f0ee8c6b34fe714aa7dad9a0e154a6f686e2e4d63477569726b")
+        expected_packed_message = build_byte_string(
+            "0180c2000003001422e9545e888e010000220201002204103a535f0ee8c6b34fe714aa7dad9a0e154a6f686e2e4d63477569726b")  # pylint: disable=line-too-long
         message = Md5ChallengeMessage(src_mac=MacAddress.from_string("00:14:22:e9:54:5e"),
                                       message_id=1,
                                       code=Eap.RESPONSE,
@@ -201,7 +205,7 @@ class MessageParserTestCase(unittest.TestCase):
                                            "1e1434342d34342d34342d34342d34342d34343a"
                                            "3d060000000f"
                                            "4f08027100061500"
-                                           "1812f51d90b0f76c85835ed4ac882e522748501201531ea8051d136941fece17473f6b4a")
+                                           "1812f51d90b0f76c85835ed4ac882e522748501201531ea8051d136941fece17473f6b4a")  # pylint: disable=line-too-long
 
         src_mac = MacAddress.from_string("02:42:ac:17:00:6f")
         username = "user"

--- a/test/test_message_parser.py
+++ b/test/test_message_parser.py
@@ -18,7 +18,8 @@ class MessageParserTestCase(unittest.TestCase):
         self.assertEqual("", message.identity)
 
     def test_identity_response_message_parses(self):
-        packed_message = build_byte_string("0180c2000003001422e9545e888e0100001102000011014a6f686e2e4d63477569726b")
+        packed_message = build_byte_string(
+            "0180c2000003001422e9545e888e0100001102000011014a6f686e2e4d63477569726b")
         message = MessageParser.ethernet_parse(packed_message)[0]
         self.assertEqual(MacAddress.from_string("00:14:22:e9:54:5e"), message.src_mac)
         self.assertEqual(0, message.message_id)
@@ -26,7 +27,8 @@ class MessageParserTestCase(unittest.TestCase):
         self.assertEqual("John.McGuirk", message.identity)
 
     def test_md5_challenge_request_message_parses(self):
-        packed_message = build_byte_string("0180c2000003001906eab88c888e01000016010100160410824788d693e2adac6ce15641418228cf0000")
+        packed_message = build_byte_string(
+            "0180c2000003001906eab88c888e01000016010100160410824788d693e2adac6ce15641418228cf0000")
         message = MessageParser.ethernet_parse(packed_message)[0]
         self.assertEqual(MacAddress.from_string("00:19:06:ea:b8:8c"), message.src_mac)
         self.assertEqual(1, message.message_id)
@@ -35,7 +37,8 @@ class MessageParserTestCase(unittest.TestCase):
         self.assertEqual(b"", message.extra_data)
 
     def test_md5_challenge_response_message_parses(self):
-        packed_message = build_byte_string("0180c2000003001422e9545e888e010000220201002204103a535f0ee8c6b34fe714aa7dad9a0e154a6f686e2e4d63477569726b")
+        packed_message = build_byte_string(
+            "0180c2000003001422e9545e888e010000220201002204103a535f0ee8c6b34fe714aa7dad9a0e154a6f686e2e4d63477569726b")
         message = MessageParser.ethernet_parse(packed_message)[0]
         self.assertEqual(MacAddress.from_string("00:14:22:e9:54:5e"), message.src_mac)
         self.assertEqual(1, message.message_id)
@@ -44,38 +47,49 @@ class MessageParserTestCase(unittest.TestCase):
         self.assertEqual(b"John.McGuirk", message.extra_data)
 
     def test_identity_request_message_packs(self):
-        expected_packed_message = build_byte_string("0180c2000003001906eab88c888e010000050101000501")
+        expected_packed_message = build_byte_string(
+            "0180c2000003001906eab88c888e010000050101000501")
         message = IdentityMessage(src_mac=MacAddress.from_string("00:19:06:ea:b8:8c"), message_id=1,
                                   code=Eap.REQUEST, identity="")
-        packed_message = MessagePacker.ethernet_pack(message, MacAddress.from_string("00:19:06:ea:b8:8c"),
+        packed_message = MessagePacker.ethernet_pack(message,
+                                                     MacAddress.from_string("00:19:06:ea:b8:8c"),
                                                      MacAddress.from_string("01:80:c2:00:00:03"))
         self.assertEqual(expected_packed_message, packed_message)
 
     def test_identity_response_message_packs(self):
-        expected_packed_message = build_byte_string("0180c2000003001422e9545e888e0100001102000011014a6f686e2e4d63477569726b")
+        expected_packed_message = build_byte_string(
+            "0180c2000003001422e9545e888e0100001102000011014a6f686e2e4d63477569726b")
         message = IdentityMessage(src_mac=MacAddress.from_string("00:14:22:e9:54:5e"),
                                   message_id=0, code=Eap.RESPONSE, identity="John.McGuirk")
-        packed_message = MessagePacker.ethernet_pack(message, MacAddress.from_string("00:14:22:e9:54:5e"),
+        packed_message = MessagePacker.ethernet_pack(message,
+                                                     MacAddress.from_string("00:14:22:e9:54:5e"),
                                                      MacAddress.from_string("01:80:c2:00:00:03"))
         self.assertEqual(expected_packed_message, packed_message)
 
     def test_md5_challenge_request_message_packs(self):
-        expected_packed_message = build_byte_string("0180c2000003001906eab88c888e01000016010100160410824788d693e2adac6ce15641418228cf")
-        message = Md5ChallengeMessage(src_mac=MacAddress.from_string("00:19:06:ea:b8:8c"), message_id=1,
+        expected_packed_message = build_byte_string(
+            "0180c2000003001906eab88c888e01000016010100160410824788d693e2adac6ce15641418228cf")
+        message = Md5ChallengeMessage(src_mac=MacAddress.from_string("00:19:06:ea:b8:8c"),
+                                      message_id=1,
                                       code=Eap.REQUEST,
-                                      challenge=build_byte_string("824788d693e2adac6ce15641418228cf"),
+                                      challenge=build_byte_string(
+                                          "824788d693e2adac6ce15641418228cf"),
                                       extra_data=b"")
-        packed_message = MessagePacker.ethernet_pack(message, MacAddress.from_string("00:19:06:ea:b8:8c"),
+        packed_message = MessagePacker.ethernet_pack(message,
+                                                     MacAddress.from_string("00:19:06:ea:b8:8c"),
                                                      MacAddress.from_string("01:80:c2:00:00:03"))
         self.assertEqual(expected_packed_message, packed_message)
 
     def test_md5_challenge_response_message_packs(self):
         expected_packed_message = build_byte_string("0180c2000003001422e9545e888e010000220201002204103a535f0ee8c6b34fe714aa7dad9a0e154a6f686e2e4d63477569726b")
-        message = Md5ChallengeMessage(src_mac=MacAddress.from_string("00:14:22:e9:54:5e"), message_id=1,
+        message = Md5ChallengeMessage(src_mac=MacAddress.from_string("00:14:22:e9:54:5e"),
+                                      message_id=1,
                                       code=Eap.RESPONSE,
-                                      challenge=build_byte_string("3a535f0ee8c6b34fe714aa7dad9a0e15"),
+                                      challenge=build_byte_string(
+                                          "3a535f0ee8c6b34fe714aa7dad9a0e15"),
                                       extra_data=b"John.McGuirk")
-        packed_message = MessagePacker.ethernet_pack(message, MacAddress.from_string("00:14:22:e9:54:5e"),
+        packed_message = MessagePacker.ethernet_pack(message,
+                                                     MacAddress.from_string("00:14:22:e9:54:5e"),
                                                      MacAddress.from_string("01:80:c2:00:00:03"))
         self.assertEqual(expected_packed_message, packed_message)
 
@@ -88,7 +102,8 @@ class MessageParserTestCase(unittest.TestCase):
     def test_eapol_start_message_packs(self):
         expected_packed_message = build_byte_string("0180c2000003001906eab88c888e01010000")
         message = EapolStartMessage(src_mac=MacAddress.from_string("00:19:06:ea:b8:8c"))
-        packed_message = MessagePacker.ethernet_pack(message, MacAddress.from_string("00:19:06:ea:b8:8c"),
+        packed_message = MessagePacker.ethernet_pack(message,
+                                                     MacAddress.from_string("00:19:06:ea:b8:8c"),
                                                      MacAddress.from_string("01:80:c2:00:00:03"))
         self.assertEqual(expected_packed_message, packed_message)
 
@@ -101,7 +116,8 @@ class MessageParserTestCase(unittest.TestCase):
     def test_eapol_logoff_message_packs(self):
         expected_packed_message = build_byte_string("0180c2000003001906eab88c888e01020000")
         message = EapolLogoffMessage(src_mac=MacAddress.from_string("00:19:06:ea:b8:8c"))
-        packed_message = MessagePacker.ethernet_pack(message, MacAddress.from_string("00:19:06:ea:b8:8c"),
+        packed_message = MessagePacker.ethernet_pack(message,
+                                                     MacAddress.from_string("00:19:06:ea:b8:8c"),
                                                      MacAddress.from_string("01:80:c2:00:00:03"))
         self.assertEqual(expected_packed_message, packed_message)
 
@@ -114,8 +130,10 @@ class MessageParserTestCase(unittest.TestCase):
 
     def test_success_message_packs(self):
         expected_packed_message = build_byte_string("0180c2000003001906eab88c888e0100000403ff0004")
-        message = SuccessMessage(src_mac=MacAddress.from_string("00:19:06:ea:b8:8c"), message_id=255)
-        packed_message = MessagePacker.ethernet_pack(message, MacAddress.from_string("00:19:06:ea:b8:8c"),
+        message = SuccessMessage(src_mac=MacAddress.from_string("00:19:06:ea:b8:8c"),
+                                 message_id=255)
+        packed_message = MessagePacker.ethernet_pack(message,
+                                                     MacAddress.from_string("00:19:06:ea:b8:8c"),
                                                      MacAddress.from_string("01:80:c2:00:00:03"))
         self.assertEqual(expected_packed_message, packed_message)
 
@@ -128,8 +146,10 @@ class MessageParserTestCase(unittest.TestCase):
 
     def test_failure_message_packs(self):
         expected_packed_message = build_byte_string("000000000001001906eab88c888e0100000404ff0004")
-        message = FailureMessage(src_mac=MacAddress.from_string("00:19:06:ea:b8:8c"), message_id=255)
-        packed_message = MessagePacker.ethernet_pack(message, MacAddress.from_string("00:19:06:ea:b8:8c"),
+        message = FailureMessage(src_mac=MacAddress.from_string("00:19:06:ea:b8:8c"),
+                                 message_id=255)
+        packed_message = MessagePacker.ethernet_pack(message,
+                                                     MacAddress.from_string("00:19:06:ea:b8:8c"),
                                                      MacAddress.from_string("00:00:00:00:00:01"))
         self.assertEqual(expected_packed_message, packed_message)
 
@@ -144,9 +164,11 @@ class MessageParserTestCase(unittest.TestCase):
     def test_ttls_message_packs(self):
         expected_packed_message = build_byte_string("000000111101444444444444888e"
                                                     "01000006016900061520")
-        message = TtlsMessage(src_mac=MacAddress.from_string("44:44:44:44:44:44"), message_id=105, code=Eap.REQUEST,
+        message = TtlsMessage(src_mac=MacAddress.from_string("44:44:44:44:44:44"),
+                              message_id=105, code=Eap.REQUEST,
                               flags=0x20, extra_data=b'')
-        packed_message = MessagePacker.ethernet_pack(message, MacAddress.from_string("44:44:44:44:44:44"),
+        packed_message = MessagePacker.ethernet_pack(message,
+                                                     MacAddress.from_string("44:44:44:44:44:44"),
                                                      MacAddress.from_string("00:00:00:11:11:01"))
         self.assertEqual(expected_packed_message, packed_message)
 
@@ -161,9 +183,12 @@ class MessageParserTestCase(unittest.TestCase):
     def test_legacy_nak_message_packs(self):
         expected_packed_message = build_byte_string("0180c2000003000000111101888e"
                                                     "01000006026800060315")
-        message = LegacyNakMessage(src_mac=MacAddress.from_string("00:00:00:11:11:01"), message_id=104,
-                                   code=Eap.RESPONSE, desired_auth_types=[(21).to_bytes(length=1, byteorder='big')])
-        packed_message = MessagePacker.ethernet_pack(message, MacAddress.from_string("00:00:00:11:11:01"),
+        message = LegacyNakMessage(src_mac=MacAddress.from_string("00:00:00:11:11:01"),
+                                   message_id=104,
+                                   code=Eap.RESPONSE,
+                                   desired_auth_types=[(21).to_bytes(length=1, byteorder='big')])
+        packed_message = MessagePacker.ethernet_pack(message,
+                                                     MacAddress.from_string("00:00:00:11:11:01"),
                                                      MacAddress.from_string("01:80:c2:00:00:03"))
         self.assertEqual(expected_packed_message, packed_message)
 
@@ -191,6 +216,7 @@ class MessageParserTestCase(unittest.TestCase):
         eap_message = TtlsMessage(src_mac, 113, Eap.RESPONSE, 0, b'')
 
         packed_radius = MessagePacker.radius_pack(eap_message, src_mac, username, radius_packet_id,
-                                                  request_authenticator, state, secret, extra_attributes)
+                                                  request_authenticator, state, secret,
+                                                  extra_attributes)
 
         self.assertEqual(packed_message, packed_radius)

--- a/test/test_radius.py
+++ b/test/test_radius.py
@@ -97,7 +97,8 @@ class RadiusTestCase(unittest.TestCase):
                           request_authenticator_callback=
                           lambda x: bytes.fromhex("982a0ba06d3557f0dbc8ba6e823822f1"))
 
-        # TODO How can we test that response authenticator is correct but message authenticator is not?
+        # TODO How can we test that response authenticator is correct
+        #  but message authenticator is not?
         #  response authenticator relies on the message authenticator being correct.
         #  unless there is a hashing collision when messageauthenticator is wrong.
 
@@ -164,7 +165,8 @@ class RadiusTestCase(unittest.TestCase):
         attr_list.append(EAPMessage.create("6572746966696361746520417574686f72697479301e170d3138303630353033353134345a170d3138303830343033353134345a307c310b3009060355040613024652310f300d06035504080c0652616469757331153013060355040a0c0c4578616d706c6520496e632e3123302106035504030c1a4578616d706c65205365727665722043657274696669636174653120301e06092a864886f70d010901161161646d696e406578616d706c652e6f726730820122300d06092a864886f70d01010105000382010f003082010a0282010100cf5456d7e6142383101cf79275f6396e2c9b3f7cb2878d35e5ecc6f47ee11ef20bc8a8b3217a89351c55"))
         attr_list.append(EAPMessage.create("856e5cd5eed2d10037c9bcce89fbdf927e4cc4f069863acbac4accee7e80f2105ad80d837fa50a931c5b41d03c993f5e338cfd8e69e23818360053501c34c08132ec3d6e14df89ff29c5cec5c7a87d48c4afdcf9d3f8290050be5b903ba6a2a5ce2eb79c922cae70869618c75923059f9a8d62144e8ecdaf0a9f02886afa0e73e3d68037ea9fdca2bdd0f0785e05f5ac88031010c105575dbb09eb4f307547622120ee384ab454376de8e14e0afea02f1211801b6c932324ef6dba7abf3f48f8e3e84716c40b59041ec936cb273d684b22aa1c9d24e10203010001a34f304d30130603551d25040c300a06082b0601050507030130360603551d1f042f"))
         attr_list.append(EAPMessage.create("302d302ba029a0278625687474703a2f2f7777772e6578616d706c652e636f6d2f6578616d706c655f63612e63726c300d06092a864886f70d01010b0500038201010054fdcdabdc3a153dc167d6b210d1b324ecfac0e3b8d385704463a7f8ebf46e2e6952f249f4436ec66760868860e5ed50b519ec14628179472c312f507bc9349971d21f8f2b7d6b329b02fab448bd90fd4ce4dfbc78f23a8c4eed74d5589f4c3bd11b552535b8ab8a1a6ab9d1dfda21f247a93354702c12fdde1113cb8dd0e46e2a3a94547c9871df2a88943751d8276dc43f7f6aed921f43f6a33f9beba804c3d2b5781d754abe36ba58461798be8585b8b2"))
-        attr_list.append(MessageAuthenticator.create(bytes.fromhex("26e219fc875fd78976eb2b9b475b1488")))
+        attr_list.append(MessageAuthenticator.create(
+            bytes.fromhex("26e219fc875fd78976eb2b9b475b1488")))
         attr_list.append(State.create(bytes.fromhex("c1591073c33305b4fa8bd26dd27eafd9")))
         attributes = RadiusAttributesList(attr_list)
         access_challenge = RadiusAccessChallenge(6,
@@ -232,11 +234,12 @@ class RadiusTestCase(unittest.TestCase):
         self.assertRaises(ValueError, Enum.parse, bytes.fromhex("01234567890123456789"))
 
         self.assertRaises(ValueError, Text.parse, "".encode())
-        self.assertRaises(ValueError, Text.parse, "260CharacterLengthUserName260CharacterLengthUserName"
-                                                  "260CharacterLengthUserName260CharacterLengthUserName"
-                                                  "260CharacterLengthUserName260CharacterLengthUserName"
-                                                  "260CharacterLengthUserName260CharacterLengthUserName"
-                                                  "260CharacterLengthUserName260CharacterLengthUserName".encode())
+        self.assertRaises(ValueError, Text.parse,
+                          "260CharacterLengthUserName260CharacterLengthUserName"
+                          "260CharacterLengthUserName260CharacterLengthUserName"
+                          "260CharacterLengthUserName260CharacterLengthUserName"
+                          "260CharacterLengthUserName260CharacterLengthUserName"
+                          "260CharacterLengthUserName260CharacterLengthUserName".encode())
 
         self.assertRaises(ValueError, String.parse, "".encode())
         self.assertRaises(ValueError, String.parse, "260CharacterLengthState260CharacterLengthState"
@@ -247,11 +250,12 @@ class RadiusTestCase(unittest.TestCase):
                                                     "260CharacterLengthState260Char".encode())
 
         self.assertRaises(ValueError, Vsa.parse, "abcd".encode())
-        self.assertRaises(ValueError, Vsa.parse, "270CharacterLengthVSAAttribute270CharacterLengthVSAAttribute"
-                                                 "270CharacterLengthVSAAttribute270CharacterLengthVSAAttribute"
-                                                 "270CharacterLengthVSAAttribute270CharacterLengthVSAAttribute"
-                                                 "270CharacterLengthVSAAttribute270CharacterLengthVSAAttribute"
-                                                 "270CharacterLen270CharacterLen".encode())
+        self.assertRaises(ValueError, Vsa.parse,
+                          "270CharacterLengthVSAAttribute270CharacterLengthVSAAttribute"
+                          "270CharacterLengthVSAAttribute270CharacterLengthVSAAttribute"
+                          "270CharacterLengthVSAAttribute270CharacterLengthVSAAttribute"
+                          "270CharacterLengthVSAAttribute270CharacterLengthVSAAttribute"
+                          "270CharacterLen270CharacterLen".encode())
         # Cannot test Concat datatype, it does not check length
 
     def test_pack_illegal_radius_datatype_lengths(self):
@@ -262,19 +266,21 @@ class RadiusTestCase(unittest.TestCase):
         self.assertRaises(ValueError, ServiceType.create, 10000000000)
 
         self.assertRaises(ValueError, UserName.create, "")
-        self.assertRaises(ValueError, UserName.create, "260CharacterLengthUserName260CharacterLengthUserName"
-                                                       "260CharacterLengthUserName260CharacterLengthUserName"
-                                                       "260CharacterLengthUserName260CharacterLengthUserName"
-                                                       "260CharacterLengthUserName260CharacterLengthUserName"
-                                                       "260CharacterLengthUserName260CharacterLengthUserName")
+        self.assertRaises(ValueError, UserName.create,
+                          "260CharacterLengthUserName260CharacterLengthUserName"
+                          "260CharacterLengthUserName260CharacterLengthUserName"
+                          "260CharacterLengthUserName260CharacterLengthUserName"
+                          "260CharacterLengthUserName260CharacterLengthUserName"
+                          "260CharacterLengthUserName260CharacterLengthUserName")
 
         self.assertRaises(ValueError, State.create, "")
-        self.assertRaises(ValueError, State.create, "260CharacterLengthState260CharacterLengthState"
-                                                    "260CharacterLengthState260CharacterLengthState"
-                                                    "260CharacterLengthState260CharacterLengthState"
-                                                    "260CharacterLengthState260CharacterLengthState"
-                                                    "260CharacterLengthState260CharacterLengthState"
-                                                    "260CharacterLengthState260Char")
+        self.assertRaises(ValueError, State.create,
+                          "260CharacterLengthState260CharacterLengthState"
+                          "260CharacterLengthState260CharacterLengthState"
+                          "260CharacterLengthState260CharacterLengthState"
+                          "260CharacterLengthState260CharacterLengthState"
+                          "260CharacterLengthState260CharacterLengthState"
+                          "260CharacterLengthState260Char")
 
         # Cannot test Concat datatype, it does not check length
         # Cannot test VSA datatype, Nothing is using it at the moment.

--- a/test/test_radius.py
+++ b/test/test_radius.py
@@ -1,14 +1,18 @@
 import binascii
 import unittest
+
 from netils import build_byte_string
 
 from chewie.message_parser import  SuccessMessage
-from chewie.radius import *
+from chewie.radius import Radius, RadiusAccessAccept, RadiusAttributesList, \
+    InvalidResponseAuthenticatorError, RadiusAccessChallenge, RadiusAccessRequest
 from chewie.radius_attributes import UserName, ServiceType, FramedMTU, CalledStationId,\
     AcctSessionId, NASPortType, ConnectInfo, EAPMessage, MessageAuthenticator, State,\
     VendorSpecific, CallingStationId
 from chewie.radius_datatypes import Vsa, String, Enum, Text, Integer
 
+
+# pylint: disable=line-too-long
 
 class RadiusTestCase(unittest.TestCase):
     def test_radius_access_request_parses(self):

--- a/test/test_radius.py
+++ b/test/test_radius.py
@@ -1,3 +1,7 @@
+
+# pylint: disable=line-too-long
+# pylint: disable=missing-docstring
+
 import binascii
 import unittest
 
@@ -11,8 +15,6 @@ from chewie.radius_attributes import UserName, ServiceType, FramedMTU, CalledSta
     VendorSpecific, CallingStationId
 from chewie.radius_datatypes import Vsa, String, Enum, Text, Integer
 
-
-# pylint: disable=line-too-long
 
 class RadiusTestCase(unittest.TestCase):
     def test_radius_access_request_parses(self):


### PR DESCRIPTION
- A lot of this is method documentation.
- Ignored most of the invalid-name in eap_state_machine.py as they are what is used in RFC 4137
- Each byte string is broken on a different part of the message. e.g. line 1: EAPMessage, line 2: State, ...
If needed I can look up the packet in the raw pcap easily.