### PR TITLE
Remove Threads from chewie test

### DIFF
--- a/chewie/chewie.py
+++ b/chewie/chewie.py
@@ -73,6 +73,11 @@ class Chewie:
         self.setup_radius_socket()
         self.start_threads_and_wait()
 
+    def shutdown(self):
+        """kill eventlets and quit"""
+        for eventlet in self.eventlets:
+            eventlet.kill()
+
     def start_threads_and_wait(self):
         """Start the thread and wait until they complete (hopefully never)"""
         self.pool = GreenPool()


### PR DESCRIPTION
This is a step towards a more lockstep test - adding a shutdown()
function on Chewie means we can kill it in teardown. Next step is to
mock GreenPool.spawn() and hold a bunch of coroutines that we can
iterate one at a time to step forward and make it even more
deterministic