### PR TITLE
Extract radius lifecycle

### DIFF
--- a/chewie/radius_lifecycle.py
+++ b/chewie/radius_lifecycle.py
@@ -4,7 +4,8 @@ import os
 import struct
 
 from chewie.message_parser import MessagePacker
-from chewie.radius_attributes import CalledStationId, NASIdentifier, NASPortType
+from chewie.radius_attributes import EAPMessage, State, CalledStationId, NASIdentifier, NASPortType
+from chewie.event import EventRadiusMessageReceived
 
 def port_id_to_int(port_id):
     """"Convert a port_id str '00:00:00:00:aa:01 to integer'"""
@@ -44,6 +45,14 @@ class RadiusLifecycle:
                                          self.radius_secret,
                                          port_id_to_int(port_id),
                                          self.extra_radius_request_attributes)
+
+    def build_event_radius_message_received(self, radius):
+        """Build a EventRadiusMessageReceived from a radius message"""
+        eap_msg_attribute = radius.attributes.find(EAPMessage.DESCRIPTION)
+        eap_msg = eap_msg_attribute.data_type.data()
+        state = radius.attributes.find(State.DESCRIPTION)
+        self.logger.info("radius EAP: %s", eap_msg)
+        return EventRadiusMessageReceived(eap_msg, state, radius.attributes.to_dict())
 
     def generate_request_authenticator(self):
         """Workaround until we get this extracted for easy mocking"""

--- a/chewie/utils.py
+++ b/chewie/utils.py
@@ -9,7 +9,9 @@ def get_logger(logname):
 
 
 def log_method(method):
+    """Generate method for logging"""
     def wrapped(self, *args, **kwargs):
+        """Method that gets called for logging"""
         self.logger.info('Entering %s' % method.__name__)
         return method(self, *args, **kwargs)
     return wrapped

--- a/test/test_chewie.py
+++ b/test/test_chewie.py
@@ -261,7 +261,7 @@ class ChewieTestCase(unittest.TestCase):
         self.chewie.radius_lifecycle.packet_id_to_mac[56] = {'src_mac': '12:34:56:78:9a:bc',
                                                              'port_id': '00:00:00:00:00:01'}
         state_machine = self.chewie.get_state_machine('12:34:56:78:9a:bc',  # pylint: disable=invalid-name
-                                           '00:00:00:00:00:01')
+                                                      '00:00:00:00:00:01')
 
         self.assertIs(self.chewie.get_state_machine_from_radius_packet_id(56),
                       state_machine)
@@ -275,7 +275,7 @@ class ChewieTestCase(unittest.TestCase):
         FROM_SUPPLICANT.put(bytes.fromhex("0000000000010242ac17006f888e01010000"))
         
         pool = eventlet.GreenPool()
-        chewie_thread = pool.spawn(self.chewie.run)
+        pool.spawn(self.chewie.run)
 
         eventlet.sleep(0.1)
 
@@ -306,7 +306,7 @@ class ChewieTestCase(unittest.TestCase):
         FROM_SUPPLICANT.put(bytes.fromhex("0000000000010242ac17006f888e01010000"))
 
         pool = eventlet.GreenPool()
-        chewie_thread = pool.spawn(self.chewie.run)
+        pool.spawn(self.chewie.run)
 
         eventlet.sleep(0.1)
 
@@ -329,7 +329,7 @@ class ChewieTestCase(unittest.TestCase):
         FROM_SUPPLICANT.put(bytes.fromhex("0000000000010242ac17006f888e01010000"))
 
         pool = eventlet.GreenPool()
-        chewie_thread = pool.spawn(self.chewie.run)
+        pool.spawn(self.chewie.run)
 
         while not self.fake_scheduler.jobs:
             eventlet.sleep(0.1)
@@ -353,7 +353,7 @@ class ChewieTestCase(unittest.TestCase):
         FROM_SUPPLICANT.put(bytes.fromhex("0000000000010242ac17006f888e01010000"))
 
         pool = eventlet.GreenPool()
-        chewie_thread = pool.spawn(self.chewie.run)
+        pool.spawn(self.chewie.run)
 
         while not self.fake_scheduler.jobs:
             eventlet.sleep(0.1)


### PR DESCRIPTION
Create RadiusLifecycle object and move some logic into it

The main thing here is having an object to pass around instead of a bare
callback that keeps Chewie far too coupled to the RADIUS implementation.
A bit more work to be done in the test_radius suite, although this shows
we probably need to think about what the Radius -> RadiusLifecycle
relationship looks like.

There's a little more to trim out of Chewie.receive_radius_messages()
too, and that should make Chewie's responsibility a lot more obvious and
easier to test.