### PR TITLE
Test chewie with mocks

### DIFF
--- a/chewie/chewie.py
+++ b/chewie/chewie.py
@@ -180,7 +180,6 @@ class Chewie:
     def send_eap_to_state_machine(self, eap, dst_mac):
         """sends an eap message to the state machine"""
         self.logger.info("eap EAP(): %s", eap)
-        self.logger.info("Received message: %s" % eap.__dict__)
         state_machine = self.get_state_machine(eap.src_mac, dst_mac)
         event = EventMessageReceived(eap, dst_mac)
         state_machine.event(event)

--- a/chewie/chewie.py
+++ b/chewie/chewie.py
@@ -68,6 +68,10 @@ class Chewie:
         self.setup_radius_socket()
         self.start_threads_and_wait()
 
+    def running(self):
+        """Used to nicely exit the event loops"""
+        return True
+
     def shutdown(self):
         """kill eventlets and quit"""
         for eventlet in self.eventlets:
@@ -156,7 +160,7 @@ class Chewie:
 
     def send_eap_messages(self):
         """send eap messages to supplicant forever."""
-        while True:
+        while self.running():
             sleep(0)
             message, src_mac, port_mac = self.eap_output_messages.get()
             self.logger.info("Sending message %s from %s to %s" %
@@ -165,7 +169,7 @@ class Chewie:
 
     def receive_eap_messages(self):
         """receive eap messages from supplicant forever."""
-        while True:
+        while self.running():
             sleep(0)
             self.logger.info("waiting for eap.")
             packed_message = self.eap_socket.receive()
@@ -183,7 +187,7 @@ class Chewie:
 
     def send_radius_messages(self):
         """send RADIUS messages to RADIUS Server forever."""
-        while True:
+        while self.running():
             sleep(0)
             radius_output_bits = self.radius_output_messages.get()
             packed_message = self.radius_lifecycle.process_outbound(radius_output_bits)
@@ -192,7 +196,7 @@ class Chewie:
 
     def receive_radius_messages(self):
         """receive RADIUS messages from RADIUS server forever."""
-        while True:
+        while self.running():
             sleep(0)
             self.logger.info("waiting for radius.")
             packed_message = self.radius_socket.receive()

--- a/chewie/event.py
+++ b/chewie/event.py
@@ -50,6 +50,14 @@ class EventMessageReceived(Event):
         self.message = message
         self.port_id = port_id
 
+    def __eq__(self, other):
+        return self.type == other.type and \
+            self.message == other.message and \
+            self.port_id == other.port_id
+
+    def __repr__(self):
+        return "%s(\"%s\", \"%s\")" % (self.__class__.__name__, self.message, self.port_id)
+
 
 class EventPortStatusChange(Event):
     """Port status has changed (up/down)"""

--- a/test/test_chewie_mocks.py
+++ b/test/test_chewie_mocks.py
@@ -19,7 +19,7 @@ def return_if(expected, return_value):
     return inner_function
 
 FakeLogger = namedtuple('FakeLogger', ('name',)) # pylint: disable=invalid-name
-FakeMessage = namedtuple('FakeMessage', ('src_mac',)) # pylint: disable=invalid-name
+FakeEapMessage = namedtuple('FakeEapMessage', ('src_mac',)) # pylint: disable=invalid-name
 
 class ChewieWithMocksTestCase(unittest.TestCase):
     """Main chewie.py test class"""
@@ -39,11 +39,11 @@ class ChewieWithMocksTestCase(unittest.TestCase):
         self.chewie.eap_socket = Mock(**{'receive.return_value': 'message from socket'})
         ethernet_parse.side_effect = return_if(
             ('message from socket',),
-            (FakeMessage('fake src mac'), 'fake dst mac')
+            (FakeEapMessage('fake src mac'), 'fake dst mac')
             )
         self.chewie.receive_eap_messages()
         state_machine().event.assert_called_with(
-            EventMessageReceived(FakeMessage('fake src mac'), 'fake dst mac')
+            EventMessageReceived(FakeEapMessage('fake src mac'), 'fake dst mac')
             )
 
     @patch("chewie.chewie.Chewie.running", Mock(side_effect=[True, False]))
@@ -56,3 +56,18 @@ class ChewieWithMocksTestCase(unittest.TestCase):
         self.chewie.eap_output_messages.put(["output eap message", "src mac", "port mac"])
         self.chewie.send_eap_messages()
         self.chewie.eap_socket.send.assert_called_with("packed ethernet")
+
+    @patch("chewie.chewie.Chewie.running", Mock(side_effect=[True, False]))
+    @patch("chewie.chewie.MessageParser.radius_parse")
+    @patch("chewie.chewie.FullEAPStateMachine")
+    @patch("chewie.chewie.sleep", Mock())
+    def test_radius_packet_in_goes_to_state_machine(self, state_machine, radius_parse): #pylint: disable=invalid-name
+        """test radius packet goes to a state machine"""
+        # note that the state machine has to exist already - if not then we blow up
+        self.chewie.radius_socket = Mock(**{'receive.return_value': 'message from socket'})
+        #self.chewie.radius_secret = 'it\'s a secret'
+        # not checking args as we can't mock the callback
+        self.chewie.receive_radius_messages()
+        state_machine().event.assert_called_with(
+            EventMessageReceived(FakeRadiusMessage('fake src mac'))
+            )

--- a/test/test_chewie_mocks.py
+++ b/test/test_chewie_mocks.py
@@ -1,0 +1,50 @@
+"""Unittests for chewie/chewie.py"""
+
+from collections import namedtuple
+
+import unittest
+from unittest.mock import patch, Mock
+
+from eventlet.queue import Queue
+
+from chewie.chewie import Chewie
+
+class FakeSocket:
+    """Helper for socket wrappers"""
+
+    def __init__(self):
+        self.receive_queue = Queue()
+        self.send_queue = Queue()
+
+    def receive(self):
+        """Fake receive method"""
+        return self.receive_queue.get()
+
+    def send(self, data):
+        """Fake receive method"""
+        self.send_queue.put(data)
+
+FakeLogger = namedtuple('FakeLogger', ('name',)) # pylint: disable=invalid-name
+FakeMessage = namedtuple('FakeMessage', ('src_mac',)) # pylint: disable=invalid-name
+
+class ChewieWithMocksTestCase(unittest.TestCase):
+    """Main chewie.py test class"""
+
+    def setUp(self):
+        self.chewie = Chewie('lo', FakeLogger('logger name'),
+                             None, None, None,
+                             '127.0.0.1', 1812, 'SECRET',
+                             '44:44:44:44:44:44')
+
+    @patch("chewie.chewie.Chewie.running", Mock(side_effect=[True, False]))
+    @patch("chewie.chewie.MessageParser.ethernet_parse",
+           Mock(return_value=[FakeMessage('fake src mac'), 'fake dst mac'])
+          )
+    @patch("chewie.chewie.sleep", Mock())
+    def test_eap_packet_goes_to_new_state_machine(self):
+        """test EAP packet creates a new state machine and is sent on"""
+        self.chewie.eap_socket = FakeSocket()
+        self.chewie.eap_socket.receive_queue.put("input eap message")
+        self.chewie.receive_eap_messages()
+        self.assertEqual(list(self.chewie.state_machines.keys()), ['fake dst mac'])
+        self.assertEqual(list(self.chewie.state_machines['fake dst mac'].keys()), ['fake src mac'])

--- a/test/test_chewie_mocks.py
+++ b/test/test_chewie_mocks.py
@@ -5,25 +5,18 @@ from collections import namedtuple
 import unittest
 from unittest.mock import patch, Mock
 
-from eventlet.queue import Queue
-
 from chewie.chewie import Chewie
 from chewie.event import EventMessageReceived
 
-class FakeSocket:
-    """Helper for socket wrappers"""
+def return_if(expected, return_value):
+    """allows us to do expect-this-return-that style mocking"""
+    def inner_function(*args):
+        """workaround to effectively give us an anonymous function"""
+        if args == expected:
+            return return_value
+        raise Exception("Expected %s but got %s" % (expected, args))
 
-    def __init__(self):
-        self.receive_queue = Queue()
-        self.send_queue = Queue()
-
-    def receive(self):
-        """Fake receive method"""
-        return self.receive_queue.get()
-
-    def send(self, data):
-        """Fake receive method"""
-        self.send_queue.put(data)
+    return inner_function
 
 FakeLogger = namedtuple('FakeLogger', ('name',)) # pylint: disable=invalid-name
 FakeMessage = namedtuple('FakeMessage', ('src_mac',)) # pylint: disable=invalid-name
@@ -37,17 +30,29 @@ class ChewieWithMocksTestCase(unittest.TestCase):
                              '127.0.0.1', 1812, 'SECRET',
                              '44:44:44:44:44:44')
 
-    @patch("chewie.chewie.FullEAPStateMachine")
     @patch("chewie.chewie.Chewie.running", Mock(side_effect=[True, False]))
-    @patch("chewie.chewie.MessageParser.ethernet_parse",
-           Mock(return_value=[FakeMessage('fake src mac'), 'fake dst mac'])
-          )
+    @patch("chewie.chewie.MessageParser.ethernet_parse")
+    @patch("chewie.chewie.FullEAPStateMachine")
     @patch("chewie.chewie.sleep", Mock())
-    def test_eap_packet_goes_to_new_state_machine(self, state_machine):
+    def test_eap_packet_in_goes_to_new_state_machine(self, state_machine, ethernet_parse): #pylint: disable=invalid-name
         """test EAP packet creates a new state machine and is sent on"""
-        self.chewie.eap_socket = FakeSocket()
-        self.chewie.eap_socket.receive_queue.put("input eap message")
+        self.chewie.eap_socket = Mock(**{'receive.return_value': 'message from socket'})
+        ethernet_parse.side_effect = return_if(
+            ('message from socket',),
+            (FakeMessage('fake src mac'), 'fake dst mac')
+            )
         self.chewie.receive_eap_messages()
         state_machine().event.assert_called_with(
             EventMessageReceived(FakeMessage('fake src mac'), 'fake dst mac')
             )
+
+    @patch("chewie.chewie.Chewie.running", Mock(side_effect=[True, False]))
+    @patch("chewie.chewie.MessagePacker.ethernet_pack")
+    @patch("chewie.chewie.sleep", Mock())
+    def test_eap_output_packet_gets_packed_and_sent(self, ethernet_pack): #pylint: disable=invalid-name
+        """test EAP packet creates a new state machine and is sent on"""
+        self.chewie.eap_socket = Mock()
+        ethernet_pack.return_value = "packed ethernet"
+        self.chewie.eap_output_messages.put(["output eap message", "src mac", "port mac"])
+        self.chewie.send_eap_messages()
+        self.chewie.eap_socket.send.assert_called_with("packed ethernet")


### PR DESCRIPTION
Heavily mocked unit tests for the 4 main methods in Chewie. Next steps are:

- Test RadiusLifecycle in isolation
- Remove `test_chewie.py` and rename `test_chewie_mocks.py` to replace it