### PR TITLE
use PBR

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,8 +7,8 @@ Build-Depends: debhelper (>=9),
                python3-all,
                python3-setuptools,
                python3-eventlet,
-               python3-transitions
-               python3-pbr (>=1.9)
+               python3-transitions,
+               python3-pbr (>=1.9),
 Standards-Version: 3.9.6
 Homepage: https://pypi.org/project/chewie/
 X-Python3-Version: >= 3.2

--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends: debhelper (>=9),
                python3-setuptools,
                python3-eventlet,
                python3-transitions
+               python3-pbr (>=1.9)
 Standards-Version: 3.9.6
 Homepage: https://pypi.org/project/chewie/
 X-Python3-Version: >= 3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 eventlet
+pbr>=1.9
 transitions

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = chewie
-version = 0.0.12
+version = 0.0.13
 summary = A bare-bones EAPOL/802.1x implementation
 license = Apache-2
 author = Sam Russell

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,29 @@
 [metadata]
+name = chewie
+version = 0.0.12
+summary = A bare-bones EAPOL/802.1x implementation
+license = Apache-2
+author = Sam Russell
+author-email = sam.h.russell@gmail.com
+home-page = https://github.com/faucetsdn/chewie
+classifiers =
+    Development Status :: 2 - Pre-Alpha
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3
+keywords =
+    802.1x
+    dot1x
+    eap
+    eapol
+    radius
+    authentication
+    aaa
+
+[files]
+packages =
+    chewie
+
 license_file = LICENSE
 
 [bdist_wheel]

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,7 @@
 from setuptools import setup
 
-long_description = """
-    Chewie is an EAPOL/802.1x implementation in Python.
-
-    Currently barely works, useful if you have one user and their password is "microphone"
-
-    More information at https://github.com/faucetsdn/chewie
-"""
 
 setup(
-    name='chewie',
-    description='A bare-bones EAPOL/802.1x implementation',
-    long_description=long_description,
-    version='0.0.12',
-    url='https://github.com/faucetsdn/chewie',
-    author='Sam Russell',
-    author_email='sam.h.russell@gmail.com',
-    license='Apache2',
-    classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3'
-    ],
-    keywords='802.1x dot1x eap eapol radius authentication aaa',
-    packages=['chewie'],
-    python_requires='>=3',
-    install_requires=[
-        'eventlet',
-        'transitions'
-    ]
+    setup_requires=['pbr>=1.9', 'setuptools>=17.1'],
+    pbr=True
 )


### PR DESCRIPTION
From what i can tell this is right, but could have missed something, especially the Debian side.

I am wondering if python3-transitions & python3-eventlet from 'Build-Depends' should be under 'Depends' instead?

closes #14 