### PR TITLE
add port id to state machine logger prefix

### DIFF
--- a/chewie/chewie.py
+++ b/chewie/chewie.py
@@ -257,9 +257,11 @@ class Chewie:
             self.state_machines[port_id_str] = {}
         state_machine = self.state_machines[port_id_str].get(src_mac_str, None)
         if not state_machine:
-            state_machine = FullEAPStateMachine(self.eap_output_messages, self.radius_output_messages, src_mac,
+            log_prefix = "%s.SM - port: %s, client: %s" % (self.logger.name, src_mac, port_id_str)
+            state_machine = FullEAPStateMachine(self.eap_output_messages,
+                                                self.radius_output_messages, src_mac,
                                                 self.timer_scheduler, self.auth_success,
-                                                self.auth_failure, self.auth_logoff, self.logger.name)
+                                                self.auth_failure, self.auth_logoff, log_prefix)
             state_machine.eap_restart = True
             # TODO what if port is not actually enabled, but then how did they auth?
             state_machine.port_enabled = True

--- a/chewie/eap_state_machine.py
+++ b/chewie/eap_state_machine.py
@@ -354,8 +354,7 @@ class FullEAPStateMachine:
         # and self.m is the one currently in use.
         # if we want to deal with each method locally.
         self.m = MPassthrough()  # pylint: disable=invalid-name
-        logname = ".SM - %s" % self.src_mac
-        self.logger = get_logger(log_prefix + logname)
+        self.logger = get_logger(log_prefix)
 
     def is_eap_restart(self):
         return self.eap_restart

--- a/test/test_full_state_machine.py
+++ b/test/test_full_state_machine.py
@@ -60,10 +60,12 @@ class FullStateMachineStartTestCase(unittest.TestCase):
         self.radius_output_queue = Queue()
         self.timer_scheduler = FakeTimerScheduler()
         self.src_mac = MacAddress.from_string("00:12:34:56:78:90")
+        log_prefix = "chewie.SM - port: %s, client: %s" % (self.src_mac, self.PORT_ID_MAC)
+
         self.sm = FullEAPStateMachine(self.eap_output_queue, self.radius_output_queue, self.src_mac,
                                       self.timer_scheduler,
                                       self.auth_handler, self.failure_handler, self.logoff_handler,
-                                      'Chewie')
+                                      log_prefix)
         # find ways to inject these - overriding consts isn't ideal
         self.MAX_RETRANSMITS = 3
         self.sm.MAX_RETRANS = self.MAX_RETRANSMITS


### PR DESCRIPTION
A MAC can appear on multiple ports. So it would be good to be able to distinguish between state machines  in the logs (state machine belongs to a unique port/mac combo).