### PR TITLE
Add MAB Functionality to Chewie and Clean up State Machines for SoC

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update && \
-    apt-get install -y python3 python3-pip
+    apt-get install -y python3 python3-pip bc git
 
 # Install Dependencies
 COPY ./requirements.txt /tmp/requirements.txt

--- a/chewie/activity_socket.py
+++ b/chewie/activity_socket.py
@@ -1,21 +1,22 @@
-"""Handle activity that is not EAP on the same EAP interface
-"""
+"""Handle activity that is not EAP on the same EAP interface"""
 
-from fcntl import ioctl
 import struct
-
+from fcntl import ioctl
 from eventlet.green import socket
+
 from chewie.mac_address import MacAddress
 
-
-class IPActivitySocket:
+class ActivitySocket:
     """Handle the RADIUS socket"""
     SIOCGIFINDEX = 0x8933
     PACKET_MR_PROMISC = 1
     IP_ETHERTYPE = 0x0800
     SOL_PACKET = 263
     PACKET_ADD_MEMBERSHIP = 1
-    # IS there a point being promisc when MAC is set?
+
+    DHCP_UDP_SRC = 68
+    DHCP_UDP_DST = 67
+    UDP_IPTYPE = b'\x11'
     EAP_ADDRESS = MacAddress.from_string("01:80:c2:00:00:03")
 
     def __init__(self, interface_name):
@@ -30,29 +31,37 @@ class IPActivitySocket:
         self.set_interface_promiscuous()
 
     def send(self, data):
-        """send on eap socket.
-            data (bytes): data to send"""
-        self.socket.send(data)
+        """Not Implemented -- This socket is purely for Listening"""
+        raise NotImplementedError('Attempted to send data down the activity socket')
 
     def receive(self):
-        """receive from eap socket"""
-        return self.socket.recv(4096)
+        """Receive activity from supplicant-facing socket"""
+        # Skip all packets that are not DHCP requests
+        while True:
+            ret_val = self.socket.recv(4096)
+
+            if ret_val[23:24] == self.UDP_IPTYPE:
+                src_port = struct.unpack('>H', ret_val[34:36])[0]
+                dst_port = struct.unpack('>H', ret_val[36:38])[0]
+
+                if src_port == self.DHCP_UDP_SRC and dst_port == self.DHCP_UDP_DST:
+                    return ret_val
 
     def open(self):
-        """Setup EAP socket"""
-        # TODO Add removal for EAP frames
-        self.socket = socket.socket(socket.PF_PACKET, socket.SOCK_RAW, socket.htons(self.IP_ETHERTYPE)) # pylint: disable=no-member
+        """Listen on the Socket for any form of Eth() / IP() frames """
+        self.socket = socket.socket(socket.PF_PACKET, socket.SOCK_RAW,  # pylint: disable=no-member
+                                    socket.htons(self.IP_ETHERTYPE))    # pylint: disable=no-member
         self.socket.bind((self.interface_name, 0))
 
     def get_interface_index(self):
-        """Get the interface index of the EAP Socket"""
+        """Get the interface index of the Socket"""
         # http://man7.org/linux/man-pages/man7/netdevice.7.html
         request = struct.pack('16sI', self.interface_name.encode("utf-8"), 0)
         response = ioctl(self.socket, self.SIOCGIFINDEX, request)
         _ifname, self.interface_index = struct.unpack('16sI', response)
 
     def set_interface_promiscuous(self):
-        """Sets the EAP interface to be able to receive EAP messages"""
+        """Sets the activity interface to be able to receive messages with port_id in mac_dst"""
         request = struct.pack("IHH8s", self.interface_index, self.PACKET_MR_PROMISC,
                               len(self.EAP_ADDRESS.address), self.EAP_ADDRESS.address)
 

--- a/chewie/activity_socket.py
+++ b/chewie/activity_socket.py
@@ -1,0 +1,59 @@
+"""Handle activity that is not EAP on the same EAP interface
+"""
+
+from fcntl import ioctl
+import struct
+
+from eventlet.green import socket
+from chewie.mac_address import MacAddress
+
+
+class IPActivitySocket:
+    """Handle the RADIUS socket"""
+    SIOCGIFINDEX = 0x8933
+    PACKET_MR_PROMISC = 1
+    IP_ETHERTYPE = 0x0800
+    SOL_PACKET = 263
+    PACKET_ADD_MEMBERSHIP = 1
+    # IS there a point being promisc when MAC is set?
+    EAP_ADDRESS = MacAddress.from_string("01:80:c2:00:00:03")
+
+    def __init__(self, interface_name):
+        self.socket = None
+        self.interface_name = interface_name
+        self.interface_index = None
+
+    def setup(self):
+        """Set up the socket"""
+        self.open()
+        self.get_interface_index()
+        self.set_interface_promiscuous()
+
+    def send(self, data):
+        """send on eap socket.
+            data (bytes): data to send"""
+        self.socket.send(data)
+
+    def receive(self):
+        """receive from eap socket"""
+        return self.socket.recv(4096)
+
+    def open(self):
+        """Setup EAP socket"""
+        # TODO Add removal for EAP frames
+        self.socket = socket.socket(socket.PF_PACKET, socket.SOCK_RAW, socket.htons(self.IP_ETHERTYPE)) # pylint: disable=no-member
+        self.socket.bind((self.interface_name, 0))
+
+    def get_interface_index(self):
+        """Get the interface index of the EAP Socket"""
+        # http://man7.org/linux/man-pages/man7/netdevice.7.html
+        request = struct.pack('16sI', self.interface_name.encode("utf-8"), 0)
+        response = ioctl(self.socket, self.SIOCGIFINDEX, request)
+        _ifname, self.interface_index = struct.unpack('16sI', response)
+
+    def set_interface_promiscuous(self):
+        """Sets the EAP interface to be able to receive EAP messages"""
+        request = struct.pack("IHH8s", self.interface_index, self.PACKET_MR_PROMISC,
+                              len(self.EAP_ADDRESS.address), self.EAP_ADDRESS.address)
+
+        self.socket.setsockopt(self.SOL_PACKET, self.PACKET_ADD_MEMBERSHIP, request)

--- a/chewie/auth_8021x.py
+++ b/chewie/auth_8021x.py
@@ -1,9 +1,10 @@
-import struct
+"""This module provides a way to parse and pack and EAPOL Packet using Auth8021x"""
 
+import struct
 from chewie.utils import MessageParseError
 
 
-def hwaddr_to_string(hwaddr):
+def hwaddr_to_string(hwaddr):  # pylint: disable=missing-docstring
     return ":".join(["%02x" % x for x in hwaddr])
 
 
@@ -12,6 +13,7 @@ AUTH_8021X_HEADER_LENGTH = 1 + 1 + 2
 
 class Auth8021x:
     """basically a EAPOL packet"""
+
     def __init__(self, version, packet_type, data):
         self.version = version
         self.packet_type = packet_type
@@ -32,7 +34,7 @@ class Auth8021x:
                                                          packed_message[:AUTH_8021X_HEADER_LENGTH])
         except struct.error as exception:
             raise MessageParseError("Auth8021x unable to parse first 4 bytes") from exception
-        data = packed_message[AUTH_8021X_HEADER_LENGTH:AUTH_8021X_HEADER_LENGTH+length]
+        data = packed_message[AUTH_8021X_HEADER_LENGTH:AUTH_8021X_HEADER_LENGTH + length]
         return cls(version, packet_type, data)
 
     def pack(self):
@@ -45,8 +47,8 @@ class Auth8021x:
 
     def __repr__(self):
         return "%s(version=%s, packet_type=%s, data=%s)" % \
-            (self.__class__.__name__, self.version, self.packet_type, self.data)
+               (self.__class__.__name__, self.version, self.packet_type, self.data)
 
     def __str__(self):
         return "%s<packet_type=%d, data=%s>" % \
-            (self.__class__.__name__, self.packet_type, self.data)
+               (self.__class__.__name__, self.packet_type, self.data)

--- a/chewie/eap_socket.py
+++ b/chewie/eap_socket.py
@@ -1,10 +1,11 @@
-"""Handle the EAP socket
-"""
-from fcntl import ioctl
-import struct
+"""Handle the EAP socket"""
 
+import struct
+from fcntl import ioctl
 from eventlet.green import socket
+
 from chewie.mac_address import MacAddress
+
 
 class EapSocket:
     """Handle the EAP socket"""
@@ -36,7 +37,9 @@ class EapSocket:
 
     def open(self):
         """Setup EAP socket"""
-        self.socket = socket.socket(socket.PF_PACKET, socket.SOCK_RAW, socket.htons(0x888e)) # pylint: disable=no-member
+
+        self.socket = socket.socket(socket.PF_PACKET, socket.SOCK_RAW,  # pylint: disable=no-member
+                                    socket.htons(0x888e))               # pylint: disable=no-member
         self.socket.bind((self.interface_name, 0))
 
     def get_interface_index(self):

--- a/chewie/ethernet_packet.py
+++ b/chewie/ethernet_packet.py
@@ -1,4 +1,6 @@
+"""This module is used to allow parsing and packing of Ethernet Packets"""
 import struct
+
 from chewie.mac_address import MacAddress
 from chewie.utils import MessageParseError
 
@@ -7,6 +9,7 @@ ETHERNET_HEADER_LENGTH = 6 + 6 + 2
 
 class EthernetPacket:
     """Packet/parsers for an IEEE 802.3 Ethernet frame"""
+
     def __init__(self, dst_mac, src_mac, ethertype, data):
         self.dst_mac = dst_mac
         self.src_mac = src_mac
@@ -41,4 +44,4 @@ class EthernetPacket:
 
     def __repr__(self):
         return "%s(dst_mac=%s, src_mac=%s, ethertype=0x%04X)" % \
-            (self.__class__.__name__, self.dst_mac, self.src_mac, self.ethertype)
+               (self.__class__.__name__, self.dst_mac, self.src_mac, self.ethertype)

--- a/chewie/event.py
+++ b/chewie/event.py
@@ -59,6 +59,20 @@ class EventMessageReceived(Event):
         return "%s(\"%s\", \"%s\")" % (self.__class__.__name__, self.message, self.port_id)
 
 
+class EventPreemptiveEAPResponseMessageReceived(EventMessageReceived):
+    """Radius Message Received."""
+
+    def __init__(self, message, port_id, preemptive_eap_id):
+        """
+        Args:
+            message:
+            port_id:
+            preemptive_eap_id:
+        """
+        super().__init__(message, port_id)
+        self.preemptive_eap_id = preemptive_eap_id
+
+
 class EventPortStatusChange(Event):
     """Port status has changed (up/down)"""
 
@@ -86,6 +100,7 @@ class EventRadiusMessageReceived(EventMessageReceived):
         super().__init__(message, None)
         self.state = state
         self.attributes = attributes
+
 
 
 class EventShutdown(Event):

--- a/chewie/event.py
+++ b/chewie/event.py
@@ -1,8 +1,7 @@
 """Various Events used by Chewie"""
 
+
 # pylint: disable=too-few-public-methods
-
-
 class Event:
     """Base event class"""
     TIMER_EXPIRED = 1
@@ -14,6 +13,7 @@ class Event:
 
 class EventTimerExpired(Event):
     """Used when a timer has expired."""
+
     def __init__(self, state_machine=None, sent_count=None):
         """
         Args:
@@ -28,6 +28,7 @@ class EventTimerExpired(Event):
 
 class EventSessionTimeout(Event):
     """User's session should be terminated."""
+
     def __init__(self, state_machine=None):
         """
         Args:
@@ -39,6 +40,7 @@ class EventSessionTimeout(Event):
 
 class EventMessageReceived(Event):
     """Message (EAP) Received. Radius Message event is a child"""
+
     def __init__(self, message, port_id):
         """
         Args:
@@ -52,8 +54,8 @@ class EventMessageReceived(Event):
 
     def __eq__(self, other):
         return self.type == other.type and \
-            self.message == other.message and \
-            self.port_id == other.port_id
+               self.message == other.message and \
+               self.port_id == other.port_id
 
     def __repr__(self):
         return "%s(\"%s\", \"%s\")" % (self.__class__.__name__, self.message, self.port_id)
@@ -102,9 +104,9 @@ class EventRadiusMessageReceived(EventMessageReceived):
         self.attributes = attributes
 
 
-
 class EventShutdown(Event):
     """Shutdown has been signaled (is this even used?)"""
+
     def __init__(self):
         # will work but please do this properly
         self.type = self.SHUTDOWN

--- a/chewie/mac_address.py
+++ b/chewie/mac_address.py
@@ -4,12 +4,12 @@ import re
 
 # pylint: disable=too-few-public-methods
 
-
 _MAC_REGEX = re.compile(r'(?:[0-9a-f]{1,2}:){5}[0-9a-f]{1,2}\Z', re.IGNORECASE)
 
 
 class MacAddress:
     """Class for comparing mac addresses"""
+
     def __init__(self, address):
         self.address = address
 

--- a/chewie/message_parser.py
+++ b/chewie/message_parser.py
@@ -1,13 +1,12 @@
+""""""
 
-# pylint: disable=too-few-public-methods
-
-from chewie.radius import RadiusAttributesList, RadiusAccessRequest, Radius
-from chewie.radius_attributes import CallingStationId, UserName, MessageAuthenticator, EAPMessage, \
-    NASPort, UserPassword
-from chewie.ethernet_packet import EthernetPacket
 from chewie.auth_8021x import Auth8021x
 from chewie.eap import Eap, EapIdentity, EapMd5Challenge, EapSuccess, EapFailure, EapLegacyNak, \
     EapTTLS, EapTLS, EapPEAP, PARSERS_TYPES
+from chewie.ethernet_packet import EthernetPacket
+from chewie.radius import RadiusAttributesList, RadiusAccessRequest, Radius
+from chewie.radius_attributes import CallingStationId, UserName, MessageAuthenticator, EAPMessage, \
+    NASPort, UserPassword
 from chewie.utils import MessageParseError
 
 
@@ -87,6 +86,7 @@ class Md5ChallengeMessage(EapMessage):
 
 class TlsMessageBase(EapMessage):
     """TLS and TTLS will extend this class, but TTLS cannot be same type as TLS"""
+
     def __init__(self, src_mac, message_id, code, flags, extra_data):
         super().__init__(src_mac, message_id)
         self.code = code
@@ -140,7 +140,6 @@ EAP_MESSAGES = {
     Eap.TTLS: TtlsMessage,
     Eap.PEAP: PeapMessage,
 }
-
 
 AUTH_8021X_MESSAGES = {
     0: "eap",
@@ -200,7 +199,7 @@ class MessageParser:
                                     ethernet_packet)
 
         return MessageParser.one_x_parse(ethernet_packet.data, ethernet_packet.src_mac), \
-            ethernet_packet.dst_mac
+               ethernet_packet.dst_mac
 
     @staticmethod
     def radius_parse(packed_message, secret, radius_lifecycle):
@@ -242,19 +241,16 @@ class MessagePacker:
         if nas_port:
             attr_list.append(NASPort.create(nas_port))
 
-        # Get Password
-        #TODO will be an issue with types here
         ciphertext = UserPassword.encrypt(secret, request_authenticator, no_dots_mac)
         attr_list.append(UserPassword.create(ciphertext))
 
         attr_list.append(MessageAuthenticator.create(
-                bytes.fromhex("00000000000000000000000000000000")))
+            bytes.fromhex("00000000000000000000000000000000")))
 
         attributes = RadiusAttributesList(attr_list)
         access_request = RadiusAccessRequest(radius_packet_id, request_authenticator, attributes)
         return access_request.build(secret)
 
-    # TODO Remove dependency on EAP
     @staticmethod
     def radius_pack(eap_message, src_mac, username, radius_packet_id,
                     request_authenticator, state, secret, nas_port=None, extra_attributes=None):

--- a/chewie/message_parser.py
+++ b/chewie/message_parser.py
@@ -3,7 +3,7 @@
 
 from chewie.radius import RadiusAttributesList, RadiusAccessRequest, Radius
 from chewie.radius_attributes import CallingStationId, UserName, MessageAuthenticator, EAPMessage, \
-    NASPort
+    NASPort, UserPassword
 from chewie.ethernet_packet import EthernetPacket
 from chewie.auth_8021x import Auth8021x
 from chewie.eap import Eap, EapIdentity, EapMd5Challenge, EapSuccess, EapFailure, EapLegacyNak, \
@@ -230,6 +230,31 @@ class MessagePacker:
                                          ethertype=0x888e, data=data)
         return ethernet_packet.pack()
 
+    @staticmethod
+    def radius_mab_pack(src_mac, radius_packet_id, request_authenticator, secret, nas_port):
+        """"""
+
+        attr_list = []
+        no_dots_mac = str(src_mac).replace(':', "")
+        attr_list.append(UserName.create(no_dots_mac))
+        attr_list.append(CallingStationId.create(str(src_mac).replace(':', '-')))
+
+        if nas_port:
+            attr_list.append(NASPort.create(nas_port))
+
+        # Get Password
+        #TODO will be an issue with types here
+        ciphertext = UserPassword.encrypt(secret, request_authenticator, no_dots_mac)
+        attr_list.append(UserPassword.create(ciphertext))
+
+        attr_list.append(MessageAuthenticator.create(
+                bytes.fromhex("00000000000000000000000000000000")))
+
+        attributes = RadiusAttributesList(attr_list)
+        access_request = RadiusAccessRequest(radius_packet_id, request_authenticator, attributes)
+        return access_request.build(secret)
+
+    # TODO Remove dependency on EAP
     @staticmethod
     def radius_pack(eap_message, src_mac, username, radius_packet_id,
                     request_authenticator, state, secret, nas_port=None, extra_attributes=None):

--- a/chewie/radius.py
+++ b/chewie/radius.py
@@ -1,10 +1,10 @@
 """RADIUS Packets"""
 import copy
-import binascii
 import hashlib
 import hmac
 import struct
 
+import binascii
 from chewie.radius_attributes import ATTRIBUTE_TYPES, Attribute, MessageAuthenticator
 from chewie.radius_datatypes import Concat
 from chewie.utils import MessageParseError
@@ -53,7 +53,8 @@ class Radius:
         """
         try:
             code, packet_id, length, authenticator = struct.unpack("!BBH16s",
-                                                                   packed_message[:RADIUS_HEADER_LENGTH])
+                                                                   packed_message[
+                                                                   :RADIUS_HEADER_LENGTH])
         except struct.error as exception:
             raise MessageParseError('Unable to unpack first 20 bytes of RADIUS header') \
                 from exception

--- a/chewie/radius.py
+++ b/chewie/radius.py
@@ -77,7 +77,7 @@ class Radius:
                                                      code=code)
             except (InvalidMessageAuthenticatorError,
                     InvalidResponseAuthenticatorError) as exception:
-                raise MessageParseError("Unable to parse Radius packet") \
+                raise MessageParseError("Unable to validate Radius packet") \
                     from exception
         raise MessageParseError("Unable to parse radius code: %d" % code)
 

--- a/chewie/radius_attributes.py
+++ b/chewie/radius_attributes.py
@@ -3,12 +3,14 @@
 # TODO could we auto generate this from the radius-types-2.csv available from iana.org?
 
 import struct
+import math
+from hashlib import md5
 
 from chewie.radius_datatypes import Concat, Enum, Integer, String, Text, Vsa
 
-
 ATTRIBUTE_TYPES = {}
 
+# TODO Fix Class Docstrings
 
 class Attribute():
     """Parent class for the Attributes."""
@@ -75,13 +77,75 @@ class UserName(Attribute):
     DESCRIPTION = "User-Name"
 
 
+# Experimental
+@register_attribute_type
+class UserPassword(Attribute):
+    """User-Password https://tools.ietf.org/html/rfc2865#section-5.2"""
+    TYPE = 2
+    DATA_TYPE = String
+    DESCRIPTION = "User-Password"
+
+    # TODO Move encryption / decryption to the appropriate place -
+    # cannot be in pack / unpack due to RA / secret requirements
+    @staticmethod
+    def encrypt(secret, req_authenticator, password):
+        def string_pop(s, length):
+            return s[:length], s[length:]
+
+        if type(secret) is str:
+            secret = secret.encode()
+
+        if type(req_authenticator) is int:
+            req_authenticator = req_authenticator.to_bytes(16, 'big')
+
+        BASE = 16
+        ciphertext = bytes()
+
+        padded_width = math.ceil(len(password) / BASE) * BASE
+        padded_password = password.ljust(padded_width, chr(0)).encode()
+        b_sec = md5(secret + req_authenticator).digest()
+
+        while len(padded_password) > 0:
+            p_sec, padded_password = string_pop(padded_password, BASE)
+            cipher_array = [x ^ y for x, y in zip(b_sec, p_sec)]
+            c_sec = bytes(cipher_array)
+            ciphertext += c_sec
+
+            b_sec = md5(secret + c_sec).digest()
+
+        return ciphertext
+
+    @staticmethod
+    def decrypt(secret, req_authenticator, ciphertext):
+        def string_pop(s, length):
+            return s[:length], s[length:]
+
+        if type(secret) is str:
+            secret = secret.encode()
+
+        if type(req_authenticator) is int:
+            req_authenticator = req_authenticator.to_bytes(16, 'big')
+
+        BASE = 16
+        cleartext = ""
+        b_sec = md5(secret + req_authenticator).digest()
+
+        while len(ciphertext) > 0:
+            c_sec,  ciphertext = string_pop(ciphertext, BASE)
+            pass_array = [x ^ y for x, y in zip(b_sec, c_sec)]
+            p_sec = bytes(pass_array)
+            cleartext += p_sec.decode('ascii')
+
+            b_sec = md5(secret + c_sec).digest()
+        return cleartext.strip('\0')
+
+
 @register_attribute_type
 class NASIPAddress(Attribute):
     """Service-Type https://tools.ietf.org/html/rfc2865#section-5.4"""
     TYPE = 4
     DATA_TYPE = String
     DESCRIPTION = "NAS-IP-Address"
-
 
 @register_attribute_type
 class NASPort(Attribute):
@@ -240,3 +304,11 @@ class TunnelPrivateGroupID(Attribute):
     TYPE = 81
     DATA_TYPE = String
     DESCRIPTION = "Tunnel-Private-Group-ID"
+
+# Experimental
+@register_attribute_type
+class NASFilterRule(Attribute):
+    """NAS-Fitler-Rule https://freeradius.org/rfc/rfc4849.html"""
+    TYPE = 92
+    DATA_TYPE = String
+    DESCRIPTION = "NAS-Filter-Rule"

--- a/chewie/radius_attributes.py
+++ b/chewie/radius_attributes.py
@@ -3,12 +3,13 @@
 # TODO could we auto generate this from the radius-types-2.csv available from iana.org?
 
 import struct
-import math
 from hashlib import md5
 
+import math
 from chewie.radius_datatypes import Concat, Enum, Integer, String, Text, Vsa
 
 ATTRIBUTE_TYPES = {}
+
 
 # TODO Fix Class Docstrings
 
@@ -131,7 +132,7 @@ class UserPassword(Attribute):
         b_sec = md5(secret + req_authenticator).digest()
 
         while len(ciphertext) > 0:
-            c_sec,  ciphertext = string_pop(ciphertext, BASE)
+            c_sec, ciphertext = string_pop(ciphertext, BASE)
             pass_array = [x ^ y for x, y in zip(b_sec, c_sec)]
             p_sec = bytes(pass_array)
             cleartext += p_sec.decode('ascii')
@@ -146,6 +147,7 @@ class NASIPAddress(Attribute):
     TYPE = 4
     DATA_TYPE = String
     DESCRIPTION = "NAS-IP-Address"
+
 
 @register_attribute_type
 class NASPort(Attribute):
@@ -304,6 +306,7 @@ class TunnelPrivateGroupID(Attribute):
     TYPE = 81
     DATA_TYPE = String
     DESCRIPTION = "Tunnel-Private-Group-ID"
+
 
 # Experimental
 @register_attribute_type

--- a/chewie/radius_datatypes.py
+++ b/chewie/radius_datatypes.py
@@ -1,8 +1,8 @@
 """Radius Attribute Datatypes"""
-import math
 import struct
 
 import chewie.message_parser
+import math
 from chewie.utils import MessageParseError
 
 
@@ -71,7 +71,7 @@ class Integer(DataType):
                 bytes_data = raw_data.to_bytes(self.MAX_DATA_LENGTH, "big")
             except OverflowError as exception:
                 raise ValueError("Integer must be >= 0  and <= 2^32-1, was %d" %
-                                                raw_data)
+                                 raw_data)
         self.bytes_data = bytes_data
 
     @classmethod
@@ -87,7 +87,7 @@ class Integer(DataType):
         return struct.pack("!4s", self.bytes_data)
 
     def data(self):
-        return int.from_bytes(self.bytes_data, 'big') # pytype: disable=attribute-error
+        return int.from_bytes(self.bytes_data, 'big')  # pytype: disable=attribute-error
 
     def data_length(self):
         return 4
@@ -118,7 +118,7 @@ class Enum(DataType):
         return struct.pack("!4s", self.bytes_data)
 
     def data(self):
-        return int.from_bytes(self.bytes_data, 'big') # pytype: disable=attribute-error
+        return int.from_bytes(self.bytes_data, 'big')  # pytype: disable=attribute-error
 
     def data_length(self):
         return 4
@@ -232,7 +232,7 @@ class Concat(DataType):
 
     def full_length(self):
         return self.AVP_HEADER_LEN * \
-               (math.ceil(len(self.bytes_data) / self.MAX_DATA_LENGTH + 1))\
+               (math.ceil(len(self.bytes_data) / self.MAX_DATA_LENGTH + 1)) \
                + len(self.bytes_data) - self.AVP_HEADER_LEN
 
     def data_length(self):
@@ -240,7 +240,6 @@ class Concat(DataType):
 
 
 class Vsa(DataType):
-
     DATA_TYPE_VALUE = 14
     VENDOR_ID_LEN = 4
     MIN_DATA_LENGTH = 5

--- a/chewie/radius_lifecycle.py
+++ b/chewie/radius_lifecycle.py
@@ -3,20 +3,24 @@
 import os
 import struct
 
-from chewie.message_parser import MessagePacker
-from chewie.radius_attributes import EAPMessage, State, CalledStationId, NASIdentifier, NASPortType
 from chewie.event import EventRadiusMessageReceived
 from chewie.mac_address import MacAddress
+from chewie.message_parser import MessagePacker
+from chewie.radius_attributes import State, CalledStationId, NASIdentifier, NASPortType
+
 
 def port_id_to_int(port_id):
     """"Convert a port_id str '00:00:00:aa:00:01 to integer'"""
     dp, port_half_1, port_half_2 = str(port_id).split(':')[3:]
     port = port_half_1 + port_half_2
-    return int.from_bytes(struct.pack('!HH', int(dp, 16), int(port, 16)), 'big')  # pytype: disable=attribute-error
+    return int.from_bytes(struct.pack('!HH', int(dp, 16), # pytype: disable=attribute-error
+                                      int(port, 16)), 'big')
+
 
 
 class RadiusLifecycle:
     """A placeholder object for RADIUS logic extracted from Chewie"""
+
     def __init__(self, radius_secret, server_id, logger):
         self.radius_secret = radius_secret
         self.server_id = server_id
@@ -35,7 +39,8 @@ class RadiusLifecycle:
         username = radius_output_bits.identity
         state = radius_output_bits.state
         port_id = radius_output_bits.port_mac
-        self.logger.info("Sending Radius Packet. Mac %s %s, Username: %s ", type(src_mac), src_mac, username)
+        self.logger.info("Sending Radius Packet. Mac %s %s, Username: %s ", type(src_mac), src_mac,
+                         username)
 
         if isinstance(radius_payload, MacAddress) and radius_payload == src_mac == username:
             print("Enterting outbound mab request")
@@ -76,9 +81,8 @@ class RadiusLifecycle:
         request_authenticator = self.generate_request_authenticator()
         self.packet_id_to_request_authenticator[radius_packet_id] = request_authenticator
         return MessagePacker.radius_mab_pack(src_mac, radius_packet_id,
-                                                request_authenticator, self.radius_secret,
-                                                port_id_to_int(port_id))
-
+                                             request_authenticator, self.radius_secret,
+                                             port_id_to_int(port_id))
 
     def generate_request_authenticator(self):
         """Workaround until we get this extracted for easy mocking"""

--- a/chewie/radius_socket.py
+++ b/chewie/radius_socket.py
@@ -2,8 +2,10 @@
 """
 from eventlet.green import socket
 
+
 class RadiusSocket:
     """Handle the RADIUS socket"""
+
     def __init__(self, listen_ip, listen_port, server_ip, server_port):
         self.socket = None
         self.listen_ip = listen_ip

--- a/chewie/state_machines/mab_state_machine.py
+++ b/chewie/state_machines/mab_state_machine.py
@@ -1,176 +1,218 @@
-"""Loosely based on RFC4137 'EAP State Machines' with some interpretation"""
+"""This Module provides a Bare-bones Mac Authentication Bypass State Machine provide 802.1x
+MAB Support in Chewie"""
+
 from transitions import Machine, State
+
 from chewie.event import EventMessageReceived, EventRadiusMessageReceived
-from chewie.utils import get_logger, log_method, RadiusQueueMessage
 from chewie.radius import RadiusAccessAccept, RadiusAccessReject
+from chewie.utils import get_logger, log_method, RadiusQueueMessage
 
 
 class MacAuthenticationBypassStateMachine:
+    """This Class provides a Bare-bones Mac Authentication Bypass State Machine provide 802.1x
+    MAB Support in Chewie"""
+
+    # pylint: disable=too-many-instance-attributes
+    # REASON: Due to class being State Machine - Requires a lot of instance attributes
 
     DEFAULT_SESSION_TIMEOUT = 3600  # Number of Seconds
 
-    NO_STATE = "NO_STATE"
     DISABLED = "DISABLED"
-
-    MAB_INIT = "MAB_INIT"
-    AAA_SEND_REQUEST = "AAA_SEND_REQUEST"
-    AAA_DISCARD = "AAA_DISCARD"
-    AAA_RETRANSMIT = "AAA_RETRANSMIT"
-    AAA_SUCCESS = "AAA_SUCCESS"
-    AAA_FAILURE = "AAA_FAILURE"
-    AAA_TIMEOUT_FAILURE = "AAA_TIMEOUT_FAILURE"
-
-    AAA_RECEIVED = "AAA_RECEIVED"
+    ETH_RECEIVED = "ETH_RECEIVED"
     AAA_REQUEST = "AAA_REQUEST"
     AAA_IDLE = "AAA_IDLE"
-    AAA_RESPONSE = "AAA_RESPONSE"
+    AAA_RECEIVED = "AAA_RECEIVED"
+    AAA_SUCCESS = "AAA_SUCCESS"
+    AAA_FAILURE = "AAA_FAILURE"
 
-    STATES = [State(NO_STATE, 'mab_reset_state'),
-              State(DISABLED, 'mab_disabled_state'),
-              State(MAB_INIT, 'mab_init_state'),
-              State(AAA_REQUEST, 'aaa_request_state'),
-              State(AAA_SEND_REQUEST, 'aaa_send_request_state'),
-              State(AAA_IDLE, 'aaa_idle_state'),
-              State(AAA_RESPONSE, 'aaa_response_state'),
-              State(AAA_SUCCESS, 'aaa_success_state'),
-              State(AAA_FAILURE, 'aaa_failure_state'),
-              State(AAA_RETRANSMIT, 'aaa_retransmit_state'),
-              State(AAA_TIMEOUT_FAILURE, 'aaa_timeout_failure_state'),
-              ]
+    STATES = [
+        State(DISABLED, 'mab_disabled_state'),
+        State(ETH_RECEIVED, 'eth_received_state'),
+        State(AAA_REQUEST, 'aaa_request_state'),
+        State(AAA_IDLE, 'aaa_idle_state'),
+        State(AAA_RECEIVED, 'aaa_received_state'),
+        State(AAA_SUCCESS, 'aaa_success_state'),
+        State(AAA_FAILURE, 'aaa_failure_state'),
+    ]
 
     TRANSITIONS = [
         {'trigger': 'process', 'source': '*', 'dest': DISABLED,
-         'unless': ['is_port_enabled']},
-        {'trigger': 'process', 'source': DISABLED, 'dest': MAB_INIT,
-         'conditions': ['is_port_enabled']},
-        {'trigger': 'process', 'source': NO_STATE, 'dest': MAB_INIT,
-         'conditions': ['is_eap_restart']},
-        {'trigger': 'process', 'source': MAB_INIT, 'dest': AAA_REQUEST},
+         'unless': ['_is_port_enabled']},
+        {'trigger': 'process', 'source': '*', 'dest': DISABLED,
+         'conditions': ['_is_mab_restart']},
+
+        {'trigger': 'process', 'source': DISABLED, 'dest': ETH_RECEIVED,
+         'conditions': ['_is_eth_received']},
+
+        {'trigger': 'process', 'source': ETH_RECEIVED, 'dest': AAA_REQUEST},
         {'trigger': 'process', 'source': AAA_REQUEST, 'dest': AAA_IDLE},
-        {'trigger': 'process', 'source': AAA_IDLE, 'dest': AAA_TIMEOUT_FAILURE,
-         'conditions': ['is_aaa_timeout']},
-        {'trigger': 'process', 'source': AAA_IDLE, 'dest': AAA_RESPONSE,
-         'conditions': ['is_aaa_resp']},
-        {'trigger': 'process', 'source': AAA_RESPONSE, 'dest': AAA_FAILURE,
-         'conditions': ['is_aaa_fail']},
-        {'trigger': 'process', 'source': AAA_RESPONSE, 'dest': AAA_SUCCESS,
-         'conditions': ['is_aaa_success']},
-        ]
+
+        {'trigger': 'process', 'source': AAA_IDLE, 'dest': AAA_RECEIVED,
+         'conditions': ['_is_aaa_received']},
+
+        # Completion States
+        {'trigger': 'process', 'source': AAA_RECEIVED, 'dest': AAA_FAILURE,
+         'conditions': ['_is_aaa_fail']},
+        {'trigger': 'process', 'source': AAA_RECEIVED, 'dest': AAA_SUCCESS,
+         'conditions': ['_is_aaa_success']},
+    ]
+
+    state = None
 
     # State Variables
     port_enabled = False
-    eap_restart = False
-    aaa_timeout = False
-    aaa_resp = False
+    mab_restart = False
+    aaa_received = False
     aaa_fail = False
     aaa_success = False
 
     aaa_response_data = None
     aaa_request_data = None
+    aaa_response_attributes = None
 
-    def is_port_enabled(self):
-        return self.port_enabled
+    eth_received = True
+    eth_message_data = None
 
-    def is_eap_restart(self):
-        return self.eap_restart
+    radius_state_attribute = None
+    session_timeout = DEFAULT_SESSION_TIMEOUT
+    port_id_mac = None
 
-    def is_aaa_timeout(self):
-        return self.aaa_timeout
+    def is_in_progress(self):  # pylint: disable=missing-docstring
+        return self.port_enabled and self.state != self.AAA_SUCCESS \
+               and self.state != self.AAA_FAILURE
 
-    def is_aaa_resp(self):
-        return self.aaa_resp
-
-    def is_aaa_fail(self):
-        return self.aaa_fail
-
-    def is_aaa_success(self):
+    def is_success(self):  # pylint: disable=missing-docstring
         return self.aaa_success
 
-    def __init__(self, eap_output_queue, radius_output_queue, src_mac, timer_scheduler,
-                 auth_handler, failure_handler, logoff_handler, log_prefix):
+    #
+    # State Transition Helpers
+    #
+    def _is_port_enabled(self):  # pylint: disable=missing-docstring
+        return self.port_enabled
+
+    def _is_eth_received(self):  # pylint: disable=missing-docstring
+        return self.eth_received
+
+    def _is_mab_restart(self):  # pylint: disable=missing-docstring
+        return self.mab_restart
+
+    def _is_aaa_received(self):  # pylint: disable=missing-docstring
+        return self.aaa_received
+
+    def _is_aaa_fail(self):  # pylint: disable=missing-docstring
+        return self.aaa_fail
+
+    def _is_aaa_success(self):  # pylint: disable=missing-docstring
+        return self.aaa_success
+
+    #
+    # State Functionality
+    #
+    @log_method
+    def mab_disabled_state(self):  # pylint: disable=missing-docstring
+        self.mab_restart = False
+
+    @log_method
+    def eth_received_state(self):  # pylint: disable=missing-docstring
+        self.process_ethernet_frame()
+
+    @log_method
+    def aaa_request_state(self):  # pylint: disable=missing-docstring
+        self.send_aaa_request()
+
+    @log_method
+    def aaa_idle_state(self):  # pylint: disable=missing-docstring
+        pass
+
+    @log_method
+    def aaa_received_state(self):  # pylint: disable=missing-docstring
+        self.process_radius_message()
+
+    @log_method
+    def aaa_success_state(self):  # pylint: disable=missing-docstring
+        self.logger.info('Authentication Passed: MAC is approved for MAB %s', self.src_mac)
+        self.handle_success()
+
+    @log_method
+    def aaa_failure_state(self):  # pylint: disable=missing-docstring
+        self.logger.info('Authentication Failed: MAC is not approved for MAB %s', self.src_mac)
+        self.handle_failure()
+
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, radius_output_queue, src_mac, timer_scheduler,
+                 auth_handler, failure_handler, log_prefix):
         """
 
         Args:
-            auth_handler (callable): callable that takes input of src_mac. Called on EAP-Success.
-            eap_output_queue (Queue): where to put Messages to send to supplicant
-            failure_handler (callable): callable that takes input of src_mac. Called on EAP-Failure.
-            logoff_handler (callable): callable that takes input of src_mac. Called on EAP-Logoff.
+            auth_handler (callable): callable that takes input of src_mac. Called on MAB-Success
+            failure_handler (callable): callable that takes input of src_mac. Called on MAB-Failure.
             radius_output_queue (Queue): where to put Messages to send to AAA server
             src_mac (MacAddress): MAC address this statemachine (sm) belongs to.
             timer_scheduler (Scheduler): where to put timer events. (useful for Retransmits)
+            log_prefix (String): the prefix used when outputting logs
         """
-        self.eap_output_messages = eap_output_queue
         self.radius_output_messages = radius_output_queue
         self.src_mac = src_mac
         self.timer_scheduler = timer_scheduler
         self.auth_handler = auth_handler
         self.failure_handler = failure_handler
-        self.logoff_handler = logoff_handler
-        self.sent_count = 0
+        self.aaa_sent_count = 0
         self.set_timer = None
         self.machine = Machine(model=self, states=MacAuthenticationBypassStateMachine.STATES,
                                transitions=MacAuthenticationBypassStateMachine.TRANSITIONS,
                                queued=True,
-                               initial=MacAuthenticationBypassStateMachine.NO_STATE)
+                               initial=MacAuthenticationBypassStateMachine.DISABLED)
 
         self.logger = get_logger(log_prefix)
 
-        # probably not needed
-        self.radius_state_attribute = None
-        self.aaa_resp_data = None
-        self.eap_restart = True
-        self.session_timeout = self.DEFAULT_SESSION_TIMEOUT
-        self.port_id_mac = None
+        self.reset_variables()
+        self.port_enabled = True
+        self.eth_received = True
 
-    def mab_init_state(self):
-        self.eap_restart = False
-        return None
+    #
+    # State Functionalty Helper Functions
+    #
 
-    def reset_variable(self):
-        self.aaa_timeout = False
-        self.aaa_resp = False
+    def reset_variables(self):
+        """Reset all used state-machine variables"""
+        self.aaa_received = False
         self.aaa_fail = False
         self.aaa_success = False
         self.aaa_response_data = None
         self.aaa_request_data = None
-
+        self.eth_received = False
+        self.eth_message_data = None
+        self.aaa_response_attributes = None
+        self.port_id_mac = None
 
     def event(self, event):
-        """Processes an event.
-        """
-        self.logger.info('start state: %s', self.state)
-        self.reset_variable()
+        """Processes an event for the state machine"""
+        self.logger.info("Received event: %s with starting state: %s", event.__class__, self.state)
 
-
+        self.reset_variables()
 
         # Process Decisions
         if isinstance(event, EventMessageReceived):
             self.event_message_received(event)
         else:
-            self.logger.error('MAB State Machine error. Incorrect event received. %s', event.__dict__)
+            self.logger.error('MAB State Machine error. Incorrect event received. %s',
+                              event.__dict__)
 
-        self.handle_message_received()
-
-        # Process Information
-
-        if self.aaa_success:
-            self.handle_success()
-
-        if self.aaa_fail:
-            self.logger.info('Authentication Failed: MAC is not approved for MAB %s', self.src_mac)
-            self.handle_failure()
-
+        self.handle_event_received()
         self.logger.info('end state: %s', self.state)
 
     def handle_success(self):
-        self.logger.info("Successful MAB hitting Handle Success")
+        """Handle a AAA_Success event"""
+        self.logger.info("Successful MAB Authentication. Running Auth Handler")
         self.auth_handler(self.src_mac, str(self.port_id_mac), self.session_timeout, None, None)
 
     def handle_failure(self):
-        self.logger.info("Successful MAB hit failure")
+        """Handle a AAA_Failure event"""
+        self.logger.info("Failed MAB Authentication. Running Failure Handler")
         self.failure_handler(self.src_mac, str(self.port_id_mac))
 
-    def handle_message_received(self):
+    def handle_event_received(self):
         """Main state machine loop"""
         last_state = None
         while self.state != last_state:
@@ -178,92 +220,43 @@ class MacAuthenticationBypassStateMachine:
             self.process()  # pylint: disable=no-member # pytype: disable=attribute-error
 
     def event_message_received(self, event):
-        #TODO replace with non-bound mac
+        """Handle a message received event"""
         if event.port_id:
             self.port_id_mac = event.port_id
 
         if isinstance(event, EventRadiusMessageReceived):
-            self.process_radius_message(event)
-        else:
-            self.process_ethernet_frame(event)
+            self.aaa_received = True
+            self.aaa_response_data = event.message
+            self.aaa_response_attributes = event.attributes
 
-    def process_ethernet_frame(self, event):
-        port_id = event.port_id
-        ethernet_packet = event.message
+            if isinstance(self.aaa_response_data, RadiusAccessAccept):
+                self.aaa_success = True
+            elif isinstance(self.aaa_response_data, RadiusAccessReject):
+                self.aaa_fail = True
+
+        else:
+            self.eth_received = True
+            self.eth_message_data = event.message
+
+    def process_ethernet_frame(self):
+        """Perform checks on ethernet frames"""
+
+    def process_radius_message(self):
+        """Perform checks on Radius Packets before they're passed to the State Machine"""
+        if not isinstance(self.aaa_response_data, RadiusAccessAccept) \
+                and not isinstance(self.aaa_response_data, RadiusAccessReject):
+            raise Exception("Unexpected Packet Type in MAB state Machine: %s" %
+                            self.aaa_response_data.__dict__)
+
+    def send_aaa_request(self):
+        """Perform sending a AAA Request"""
+        port_id = self.port_id_mac
+        ethernet_packet = self.eth_message_data
         src_mac = ethernet_packet.src_mac
 
         # Build the RADIUS Packet and send
-        self.logger.info('outputing radius mab')
-
         self.radius_output_messages.put_nowait(
             RadiusQueueMessage(src_mac, src_mac, src_mac,
-            self.radius_state_attribute, port_id))
+                               self.radius_state_attribute, port_id))
 
-        self.sent_count += 1
-        # self.set_timer(self.RADIUS_RETRANSMIT_TIMEOUT)
-
-    def process_radius_message(self, event):
-        self.aaa_resp = True
-        self.logger.debug('radius attributes %s', event.attributes)
-        self.logger.debug('MAB State Machine ev.msg: %s', self.aaa_resp_data)
-        if isinstance(event.message, RadiusAccessAccept):
-                self.logger.debug("mab - aaaSuccess")
-                self.aaa_success = True
-        elif isinstance(event.message, RadiusAccessReject):
-                self.logger.debug("mab - aaaFail")
-                self.aaa_fail = True
-        else:
-            raise Exception("Unexpected Packet Type in MAB state Machine: %s" % event.__dict__)
-
-        self.logger.debug('radius event %s', event.__dict__)
-
-    #TODO
-    def is_in_progress(self):
-        return True
-
-    def is_success(self):
-        return self.aaa_success
-    # States
-    @log_method
-    def mab_reset_state(self):
-        pass
-
-    @log_method
-    def mab_disabled_state(self):
-        pass
-
-    @log_method
-    def aaa_request_state(self):
-        pass
-
-    @log_method
-    def aaa_send_request_state(self):
-        pass
-
-    @log_method
-    def aaa_idle_state(self):
-        pass
-
-    @log_method
-    def aaa_response_state(self):
-        pass
-
-    @log_method
-    def aaa_success_state(self):
-        pass
-
-    @log_method
-    def aaa_failure_state(self):
-        pass
-
-    @log_method
-    def aaa_retransmit_state(self):
-        pass
-
-    @log_method
-    def aaa_timeout_failure_state(self):
-        pass
-
-
-
-
+        self.aaa_sent_count += 1

--- a/chewie/state_machines/mab_state_machine.py
+++ b/chewie/state_machines/mab_state_machine.py
@@ -1,0 +1,269 @@
+"""Loosely based on RFC4137 'EAP State Machines' with some interpretation"""
+from transitions import Machine, State
+from chewie.event import EventMessageReceived, EventRadiusMessageReceived
+from chewie.utils import get_logger, log_method, RadiusQueueMessage
+from chewie.radius import RadiusAccessAccept, RadiusAccessReject
+
+
+class MacAuthenticationBypassStateMachine:
+
+    DEFAULT_SESSION_TIMEOUT = 3600  # Number of Seconds
+
+    NO_STATE = "NO_STATE"
+    DISABLED = "DISABLED"
+
+    MAB_INIT = "MAB_INIT"
+    AAA_SEND_REQUEST = "AAA_SEND_REQUEST"
+    AAA_DISCARD = "AAA_DISCARD"
+    AAA_RETRANSMIT = "AAA_RETRANSMIT"
+    AAA_SUCCESS = "AAA_SUCCESS"
+    AAA_FAILURE = "AAA_FAILURE"
+    AAA_TIMEOUT_FAILURE = "AAA_TIMEOUT_FAILURE"
+
+    AAA_RECEIVED = "AAA_RECEIVED"
+    AAA_REQUEST = "AAA_REQUEST"
+    AAA_IDLE = "AAA_IDLE"
+    AAA_RESPONSE = "AAA_RESPONSE"
+
+    STATES = [State(NO_STATE, 'mab_reset_state'),
+              State(DISABLED, 'mab_disabled_state'),
+              State(MAB_INIT, 'mab_init_state'),
+              State(AAA_REQUEST, 'aaa_request_state'),
+              State(AAA_SEND_REQUEST, 'aaa_send_request_state'),
+              State(AAA_IDLE, 'aaa_idle_state'),
+              State(AAA_RESPONSE, 'aaa_response_state'),
+              State(AAA_SUCCESS, 'aaa_success_state'),
+              State(AAA_FAILURE, 'aaa_failure_state'),
+              State(AAA_RETRANSMIT, 'aaa_retransmit_state'),
+              State(AAA_TIMEOUT_FAILURE, 'aaa_timeout_failure_state'),
+              ]
+
+    TRANSITIONS = [
+        {'trigger': 'process', 'source': '*', 'dest': DISABLED,
+         'unless': ['is_port_enabled']},
+        {'trigger': 'process', 'source': DISABLED, 'dest': MAB_INIT,
+         'conditions': ['is_port_enabled']},
+        {'trigger': 'process', 'source': NO_STATE, 'dest': MAB_INIT,
+         'conditions': ['is_eap_restart']},
+        {'trigger': 'process', 'source': MAB_INIT, 'dest': AAA_REQUEST},
+        {'trigger': 'process', 'source': AAA_REQUEST, 'dest': AAA_IDLE},
+        {'trigger': 'process', 'source': AAA_IDLE, 'dest': AAA_TIMEOUT_FAILURE,
+         'conditions': ['is_aaa_timeout']},
+        {'trigger': 'process', 'source': AAA_IDLE, 'dest': AAA_RESPONSE,
+         'conditions': ['is_aaa_resp']},
+        {'trigger': 'process', 'source': AAA_RESPONSE, 'dest': AAA_FAILURE,
+         'conditions': ['is_aaa_fail']},
+        {'trigger': 'process', 'source': AAA_RESPONSE, 'dest': AAA_SUCCESS,
+         'conditions': ['is_aaa_success']},
+        ]
+
+    # State Variables
+    port_enabled = False
+    eap_restart = False
+    aaa_timeout = False
+    aaa_resp = False
+    aaa_fail = False
+    aaa_success = False
+
+    aaa_response_data = None
+    aaa_request_data = None
+
+    def is_port_enabled(self):
+        return self.port_enabled
+
+    def is_eap_restart(self):
+        return self.eap_restart
+
+    def is_aaa_timeout(self):
+        return self.aaa_timeout
+
+    def is_aaa_resp(self):
+        return self.aaa_resp
+
+    def is_aaa_fail(self):
+        return self.aaa_fail
+
+    def is_aaa_success(self):
+        return self.aaa_success
+
+    def __init__(self, eap_output_queue, radius_output_queue, src_mac, timer_scheduler,
+                 auth_handler, failure_handler, logoff_handler, log_prefix):
+        """
+
+        Args:
+            auth_handler (callable): callable that takes input of src_mac. Called on EAP-Success.
+            eap_output_queue (Queue): where to put Messages to send to supplicant
+            failure_handler (callable): callable that takes input of src_mac. Called on EAP-Failure.
+            logoff_handler (callable): callable that takes input of src_mac. Called on EAP-Logoff.
+            radius_output_queue (Queue): where to put Messages to send to AAA server
+            src_mac (MacAddress): MAC address this statemachine (sm) belongs to.
+            timer_scheduler (Scheduler): where to put timer events. (useful for Retransmits)
+        """
+        self.eap_output_messages = eap_output_queue
+        self.radius_output_messages = radius_output_queue
+        self.src_mac = src_mac
+        self.timer_scheduler = timer_scheduler
+        self.auth_handler = auth_handler
+        self.failure_handler = failure_handler
+        self.logoff_handler = logoff_handler
+        self.sent_count = 0
+        self.set_timer = None
+        self.machine = Machine(model=self, states=MacAuthenticationBypassStateMachine.STATES,
+                               transitions=MacAuthenticationBypassStateMachine.TRANSITIONS,
+                               queued=True,
+                               initial=MacAuthenticationBypassStateMachine.NO_STATE)
+
+        self.logger = get_logger(log_prefix)
+
+        # probably not needed
+        self.radius_state_attribute = None
+        self.aaa_resp_data = None
+        self.eap_restart = True
+        self.session_timeout = self.DEFAULT_SESSION_TIMEOUT
+        self.port_id_mac = None
+
+    def mab_init_state(self):
+        self.eap_restart = False
+        return None
+
+    def reset_variable(self):
+        self.aaa_timeout = False
+        self.aaa_resp = False
+        self.aaa_fail = False
+        self.aaa_success = False
+        self.aaa_response_data = None
+        self.aaa_request_data = None
+
+
+    def event(self, event):
+        """Processes an event.
+        """
+        self.logger.info('start state: %s', self.state)
+        self.reset_variable()
+
+
+
+        # Process Decisions
+        if isinstance(event, EventMessageReceived):
+            self.event_message_received(event)
+        else:
+            self.logger.error('MAB State Machine error. Incorrect event received. %s', event.__dict__)
+
+        self.handle_message_received()
+
+        # Process Information
+
+        if self.aaa_success:
+            self.handle_success()
+
+        if self.aaa_fail:
+            self.logger.info('Authentication Failed: MAC is not approved for MAB %s', self.src_mac)
+            self.handle_failure()
+
+        self.logger.info('end state: %s', self.state)
+
+    def handle_success(self):
+        self.logger.info("Successful MAB hitting Handle Success")
+        self.auth_handler(self.src_mac, str(self.port_id_mac), self.session_timeout, None, None)
+
+    def handle_failure(self):
+        self.logger.info("Successful MAB hit failure")
+        self.failure_handler(self.src_mac, str(self.port_id_mac))
+
+    def handle_message_received(self):
+        """Main state machine loop"""
+        last_state = None
+        while self.state != last_state:
+            last_state = self.state
+            self.process()  # pylint: disable=no-member # pytype: disable=attribute-error
+
+    def event_message_received(self, event):
+        #TODO replace with non-bound mac
+        if event.port_id:
+            self.port_id_mac = event.port_id
+
+        if isinstance(event, EventRadiusMessageReceived):
+            self.process_radius_message(event)
+        else:
+            self.process_ethernet_frame(event)
+
+    def process_ethernet_frame(self, event):
+        port_id = event.port_id
+        ethernet_packet = event.message
+        src_mac = ethernet_packet.src_mac
+
+        # Build the RADIUS Packet and send
+        self.logger.info('outputing radius mab')
+
+        self.radius_output_messages.put_nowait(
+            RadiusQueueMessage(src_mac, src_mac, src_mac,
+            self.radius_state_attribute, port_id))
+
+        self.sent_count += 1
+        # self.set_timer(self.RADIUS_RETRANSMIT_TIMEOUT)
+
+    def process_radius_message(self, event):
+        self.aaa_resp = True
+        self.logger.debug('radius attributes %s', event.attributes)
+        self.logger.debug('MAB State Machine ev.msg: %s', self.aaa_resp_data)
+        if isinstance(event.message, RadiusAccessAccept):
+                self.logger.debug("mab - aaaSuccess")
+                self.aaa_success = True
+        elif isinstance(event.message, RadiusAccessReject):
+                self.logger.debug("mab - aaaFail")
+                self.aaa_fail = True
+        else:
+            raise Exception("Unexpected Packet Type in MAB state Machine: %s" % event.__dict__)
+
+        self.logger.debug('radius event %s', event.__dict__)
+
+    #TODO
+    def is_in_progress(self):
+        return True
+
+    def is_success(self):
+        return self.aaa_success
+    # States
+    @log_method
+    def mab_reset_state(self):
+        pass
+
+    @log_method
+    def mab_disabled_state(self):
+        pass
+
+    @log_method
+    def aaa_request_state(self):
+        pass
+
+    @log_method
+    def aaa_send_request_state(self):
+        pass
+
+    @log_method
+    def aaa_idle_state(self):
+        pass
+
+    @log_method
+    def aaa_response_state(self):
+        pass
+
+    @log_method
+    def aaa_success_state(self):
+        pass
+
+    @log_method
+    def aaa_failure_state(self):
+        pass
+
+    @log_method
+    def aaa_retransmit_state(self):
+        pass
+
+    @log_method
+    def aaa_timeout_failure_state(self):
+        pass
+
+
+
+

--- a/chewie/timer_scheduler.py
+++ b/chewie/timer_scheduler.py
@@ -1,8 +1,8 @@
 """Homebrew Event scheduler, as sched.scheduler was not working outside of unittests"""
 import heapq
-import time
 
 import eventlet
+import time
 
 
 class TimerJob:

--- a/chewie/utils.py
+++ b/chewie/utils.py
@@ -11,10 +11,12 @@ def get_logger(logname):
 
 def log_method(method):
     """Generate method for logging"""
+
     def wrapped(self, *args, **kwargs):
         """Method that gets called for logging"""
         self.logger.info('Entering %s' % method.__name__)
         return method(self, *args, **kwargs)
+
     return wrapped
 
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -9,7 +9,7 @@ fi
 
 echo "=============== Running UnitTests ================="
 
-PYTHONPATH=./ pytest --cov=chewie --cov-report term --cov-report=xml:coverage.xml test/test_*.py || exit 1
+PYTHONPATH=./ pytest -v --cov=chewie --cov-report term --cov-report=xml:coverage.xml test/test_*.py || exit 1
 
 echo "=============== Running PyType ===================="
 pytype -V$PYTYPE_TARGET_VERSION chewie/*py || exit 1

--- a/test/fuzzer/fuzz_packet.py
+++ b/test/fuzzer/fuzz_packet.py
@@ -2,23 +2,20 @@
 
 """Run AFL repeatedly with externally supplied generated packet from STDIN."""
 
-
-import sys
 from collections import namedtuple
 
 import afl  # pylint: disable=import-error
-
-from chewie.utils import MessageParseError
-
+import sys
 from chewie.mac_address import MacAddress
 from chewie.message_parser import MessageParser
-
+from chewie.utils import MessageParseError
 
 ROUNDS = 1
 
 
 class NoneDict(dict):
     """Dictionary that will always return None"""
+
     def __getitem__(self, key):
         return None  # pylint: disable=useless-return
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -4,6 +4,7 @@
 
 class FakeTimerJob:
     """Behaves like TimerJob"""
+
     def __init__(self, function, args, timeout):
         self.function = function
         self.args = args
@@ -26,6 +27,7 @@ class FakeTimerJob:
 
 class FakeTimerScheduler:
     """Behaves like TimerScheduler"""
+
     def __init__(self):
         self.jobs = []
 

--- a/test/test_auth_8021x.py
+++ b/test/test_auth_8021x.py
@@ -1,7 +1,7 @@
-
 # pylint: disable=missing-docstring
 
 import unittest
+
 from chewie.auth_8021x import Auth8021x
 
 

--- a/test/test_chewie_mocks.py
+++ b/test/test_chewie_mocks.py
@@ -1,8 +1,7 @@
 """Unittests for chewie/chewie.py"""
 
-from collections import namedtuple
-
 import unittest
+from collections import namedtuple
 from unittest.mock import patch, Mock
 
 from chewie.chewie import Chewie
@@ -12,6 +11,7 @@ from chewie.utils import EapQueueMessage
 
 def return_if(expected, return_value):
     """allows us to do expect-this-return-that style mocking"""
+
     def inner_function(*args):
         """workaround to effectively give us an anonymous function"""
         if args == expected:
@@ -20,8 +20,10 @@ def return_if(expected, return_value):
 
     return inner_function
 
-FakeLogger = namedtuple('FakeLogger', ('name',)) # pylint: disable=invalid-name
-FakeEapMessage = namedtuple('FakeEapMessage', ('src_mac',)) # pylint: disable=invalid-name
+
+FakeLogger = namedtuple('FakeLogger', ('name',))  # pylint: disable=invalid-name
+FakeEapMessage = namedtuple('FakeEapMessage', ('src_mac',))  # pylint: disable=invalid-name
+
 
 class ChewieWithMocksTestCase(unittest.TestCase):
     """Main chewie.py test class"""
@@ -36,22 +38,24 @@ class ChewieWithMocksTestCase(unittest.TestCase):
     @patch("chewie.chewie.MessageParser.ethernet_parse")
     @patch("chewie.chewie.FullEAPStateMachine")
     @patch("chewie.chewie.sleep", Mock())
-    def test_eap_packet_in_goes_to_new_state_machine(self, state_machine, ethernet_parse): #pylint: disable=invalid-name
+    def test_eap_packet_in_goes_to_new_state_machine(self, state_machine,
+                                                     ethernet_parse):  # pylint: disable=invalid-name
         """test EAP packet creates a new state machine and is sent on"""
         self.chewie.eap_socket = Mock(**{'receive.return_value': 'message from socket'})
         ethernet_parse.side_effect = return_if(
             ('message from socket',),
             (FakeEapMessage('fake src mac'), 'fake dst mac')
-            )
+        )
         self.chewie.receive_eap_messages()
         state_machine().event.assert_called_with(
             EventMessageReceived(FakeEapMessage('fake src mac'), 'fake dst mac')
-            )
+        )
 
     @patch("chewie.chewie.Chewie.running", Mock(side_effect=[True, False]))
     @patch("chewie.chewie.MessagePacker.ethernet_pack")
     @patch("chewie.chewie.sleep", Mock())
-    def test_eap_output_packet_gets_packed_and_sent(self, ethernet_pack): #pylint: disable=invalid-name
+    def test_eap_output_packet_gets_packed_and_sent(self,
+                                                    ethernet_pack):  # pylint: disable=invalid-name
         """test EAP packet creates a new state machine and is sent on"""
         self.chewie.eap_socket = Mock()
         ethernet_pack.return_value = "packed ethernet"
@@ -64,7 +68,8 @@ class ChewieWithMocksTestCase(unittest.TestCase):
     @patch("chewie.chewie.MessageParser.radius_parse")
     @patch("chewie.chewie.Chewie.get_state_machine_from_radius_packet_id")
     @patch("chewie.chewie.sleep", Mock())
-    def test_radius_packet_in_goes_to_state_machine(self, state_machine, radius_parse): #pylint: disable=invalid-name
+    def test_radius_packet_in_goes_to_state_machine(self, state_machine,
+                                                    radius_parse):  # pylint: disable=invalid-name
         """test radius packet goes to a state machine"""
         # note that the state machine has to exist already - if not then we blow up
         fake_radius = namedtuple('Radius', ('packet_id',))('fake packet id')
@@ -77,16 +82,16 @@ class ChewieWithMocksTestCase(unittest.TestCase):
         radius_parse.side_effect = return_if(
             ('message from socket', 'SECRET', self.chewie.radius_lifecycle),
             fake_radius
-            )
+        )
         # not checking args as we can't mock the callback
         self.chewie.receive_radius_messages()
         state_machine().event.assert_called_with(
             'fake event'
-            )
+        )
 
     @patch("chewie.chewie.Chewie.running", Mock(side_effect=[True, False]))
     @patch("chewie.chewie.sleep", Mock())
-    def test_radius_output_packet_gets_packed_and_sent(self): #pylint: disable=invalid-name
+    def test_radius_output_packet_gets_packed_and_sent(self):  # pylint: disable=invalid-name
         """test EAP packet creates a new state machine and is sent on"""
         self.chewie.radius_socket = Mock()
 

--- a/test/test_eap.py
+++ b/test/test_eap.py
@@ -1,7 +1,7 @@
-
 # pylint: disable=missing-docstring
 
 import unittest
+
 from chewie.eap import Eap, EapIdentity, EapMd5Challenge, EapSuccess, EapFailure
 
 

--- a/test/test_ethernet_packet.py
+++ b/test/test_ethernet_packet.py
@@ -1,7 +1,7 @@
-
 # pylint: disable=missing-docstring
 
 import unittest
+
 from chewie.ethernet_packet import EthernetPacket
 from chewie.mac_address import MacAddress
 

--- a/test/test_full_state_machine.py
+++ b/test/test_full_state_machine.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 
 from chewie.eap import Eap
-from chewie.eap_state_machine import FullEAPStateMachine
+from chewie.state_machines.eap_state_machine import FullEAPStateMachine
 from chewie.event import EventMessageReceived, EventRadiusMessageReceived, EventPortStatusChange
 from chewie.mac_address import MacAddress
 from chewie.message_parser import EapolStartMessage, IdentityMessage, Md5ChallengeMessage, \

--- a/test/test_full_state_machine.py
+++ b/test/test_full_state_machine.py
@@ -2,17 +2,18 @@
 # pylint: disable=missing-docstring
 
 import logging
-from queue import Queue
 import tempfile
 import unittest
+from queue import Queue
 
 from chewie.eap import Eap
-from chewie.state_machines.eap_state_machine import FullEAPStateMachine
 from chewie.event import EventMessageReceived, EventRadiusMessageReceived, EventPortStatusChange
 from chewie.mac_address import MacAddress
 from chewie.message_parser import EapolStartMessage, IdentityMessage, Md5ChallengeMessage, \
     SuccessMessage, LegacyNakMessage, TtlsMessage, FailureMessage, EapolLogoffMessage
 from chewie.radius_attributes import State
+from chewie.state_machines.eap_state_machine import FullEAPStateMachine
+
 from helpers import FakeTimerScheduler
 
 
@@ -20,9 +21,9 @@ def check_counters(_func=None, *,
                    expected_auth_counter=0, expected_failure_counter=0, expected_logoff_counter=0):
     """Decorator to check the handlers have been called the
      correct number of times at the end of each test"""
+
     def decorator_check_counters(func):
         def wrapper(self):
-
             start_auth_counter = self.auth_counter
             start_failure_counter = self.failure_counter
             start_logoff_counter = self.logoff_counter
@@ -36,6 +37,7 @@ def check_counters(_func=None, *,
             return ret
 
         return wrapper
+
     if _func is None:
         return decorator_check_counters
     else:
@@ -82,7 +84,8 @@ class FullStateMachineStartTestCase(unittest.TestCase):
             self.assertNotIn('aaaEapResp is true. but data is false. This should never happen',
                              log.read())
 
-    def auth_handler(self, client_mac, port_id_mac, timer, vlan_name, filter_id):  # pylint: disable=unused-argument
+    def auth_handler(self, client_mac, port_id_mac, timer, vlan_name,
+                     filter_id):  # pylint: disable=unused-argument
         self.auth_counter += 1
         print('Successful auth from MAC %s' % str(client_mac))
 
@@ -184,7 +187,6 @@ class FullStateMachineStartTestCase(unittest.TestCase):
         self.assertEqual(self.eap_output_queue.qsize(), start_eap_q_size + 0)
         self.assertEqual(self.radius_output_queue.qsize(), start_radius_q_size + 1)
         self.assertIsInstance(self.radius_output_queue.get_nowait()[0], IdentityMessage)
-
 
     @check_counters
     def test_timeout_failure2_from_aaa_timeout(self):
@@ -398,7 +400,8 @@ class FullStateMachineStartTestCase(unittest.TestCase):
         self.assertEqual(self.radius_output_queue.qsize(), 1)
 
         message = TtlsMessage(self.src_mac, 3, Eap.RESPONSE, 0x00,
-                              bytes.fromhex('16030101280100012403032c36dbf8ee16b94b28efdb8c5603e07823f9b716557b5ef2624b026daea115760000aac030c02cc028c024c014c00a00a500a300a1009f006b006a0069006800390038003700360088008700860085c032c02ec02ac026c00fc005009d003d00350084c02fc02bc027c023c013c00900a400a200a0009e00670040003f003e0033003200310030009a0099009800970045004400430042c031c02dc029c025c00ec004009c003c002f00960041c011c007c00cc00200050004c012c008001600130010000dc00dc003000a00ff01000051000b000403000102000a001c001a00170019001c001b0018001a0016000e000d000b000c0009000a000d0020001e060106020603050105020503040104020403030103020303020102020203000f000101'))
+                              bytes.fromhex(
+                                  '16030101280100012403032c36dbf8ee16b94b28efdb8c5603e07823f9b716557b5ef2624b026daea115760000aac030c02cc028c024c014c00a00a500a300a1009f006b006a0069006800390038003700360088008700860085c032c02ec02ac026c00fc005009d003d00350084c02fc02bc027c023c013c00900a400a200a0009e00670040003f003e0033003200310030009a0099009800970045004400430042c031c02dc029c025c00ec004009c003c002f00960041c011c007c00cc00200050004c012c008001600130010000dc00dc003000a00ff01000051000b000403000102000a001c001a00170019001c001b0018001a0016000e000d000b000c0009000a000d0020001e060106020603050105020503040104020403030103020303020102020203000f000101'))
         self.sm.event(EventMessageReceived(message, self.PORT_ID_MAC))
         self.assertEqual(self.sm.state, self.sm.AAA_IDLE)
         self.assertEqual(self.eap_output_queue.qsize(), 1)

--- a/test/test_mab_state_machine.py
+++ b/test/test_mab_state_machine.py
@@ -1,0 +1,143 @@
+import logging
+from queue import Queue
+import tempfile
+import unittest
+from chewie.event import EventMessageReceived, EventRadiusMessageReceived
+from chewie.mac_address import MacAddress
+from chewie.ethernet_packet import EthernetPacket
+from chewie.state_machines.mab_state_machine import MacAuthenticationBypassStateMachine
+from chewie.radius import RadiusAccessReject, RadiusAccessAccept
+
+
+# TODO Remove and create a 'test state machine' class
+def check_counters(_func=None, *,
+                   expected_auth_counter=0, expected_failure_counter=0, expected_logoff_counter=0):
+    """Decorator to check the handlers have been called the
+     correct number of times at the end of each test"""
+    def decorator_check_counters(func):
+        def wrapper(self):
+
+            start_auth_counter = self.auth_counter
+            start_failure_counter = self.failure_counter
+            start_logoff_counter = self.logoff_counter
+            ret = func(self)
+            self.assertEqual(self.auth_counter,
+                             start_auth_counter + expected_auth_counter)
+            self.assertEqual(self.failure_counter,
+                             start_failure_counter + expected_failure_counter)
+            self.assertEqual(self.logoff_counter,
+                             start_logoff_counter + expected_logoff_counter)
+            return ret
+
+        return wrapper
+    if _func is None:
+        return decorator_check_counters
+    else:
+        return decorator_check_counters(_func)
+
+class MABStateMachineTest(unittest.TestCase):
+
+    PORT_ID_MAC = MacAddress.from_string("00:00:00:00:00:01")
+
+    def setUp(self):
+        # Build the state machine
+        logger = logging.getLogger()
+        logger.level = logging.DEBUG
+        self.log_file = tempfile.NamedTemporaryFile()
+        logger.addHandler(logging.FileHandler(self.log_file.name))
+
+        self.eap_output_queue = Queue()
+        self.radius_output_queue = Queue()
+        # TODO reset
+        self.timer_scheduler = None
+        self.src_mac = MacAddress.from_string("00:12:34:56:78:90")
+        log_prefix = "chewie.SM - port: %s, client: %s" % (self.src_mac, self.PORT_ID_MAC)
+
+        self.sm = MacAuthenticationBypassStateMachine(self.eap_output_queue, self.radius_output_queue,
+                                                      self.src_mac,
+                                                      self.timer_scheduler, self.auth_handler, self.failure_handler,
+                                                      self.logoff_handler,
+                                                      log_prefix)
+
+        self.auth_counter = 0
+        self.failure_counter = 0
+        self.logoff_counter = 0
+
+
+    def tearDown(self):
+        with open(self.log_file.name) as log:
+            self.assertNotIn('aaaEapResp is true. but data is false. This should never happen',
+                             log.read())
+
+    def auth_handler(self, client_mac, port_id_mac, timer, vlan_name, filter_id):  # pylint: disable=unused-argument
+        self.auth_counter += 1
+        print('Successful auth from MAC %s' % str(client_mac))
+
+    def failure_handler(self, client_mac, port_id_mac):  # pylint: disable=unused-argument
+        self.failure_counter += 1
+        print('failure from MAC %s' % str(client_mac))
+
+    def logoff_handler(self, client_mac, port_id_mac):  # pylint: disable=unused-argument
+        self.logoff_counter += 1
+        print('logoff from MAC %s' % str(client_mac))
+
+    def receive_eth_packet(self):
+        rad_queue_size = self.radius_output_queue.qsize()
+        eap_queue_size = self.eap_output_queue.qsize()
+
+        message = EthernetPacket(self.PORT_ID_MAC, str(self.src_mac), 0x888e, "")
+        self.sm.event(EventMessageReceived(message, self.PORT_ID_MAC))
+
+        self.assertEqual(self.radius_output_queue.qsize(), rad_queue_size + 1)
+        self.assertEqual(self.eap_output_queue.qsize(), eap_queue_size)
+
+    def receive_radius_accept(self):
+        rad_queue_size = self.radius_output_queue.qsize()
+        eap_queue_size = self.eap_output_queue.qsize()
+
+        message = RadiusAccessAccept(1, 1, [])
+        self.sm.event(EventRadiusMessageReceived(message, None, []))
+
+        self.assertEqual(self.radius_output_queue.qsize(), rad_queue_size)
+        self.assertEqual(self.eap_output_queue.qsize(), eap_queue_size)
+
+    def receive_radius_reject(self):
+        rad_queue_size = self.radius_output_queue.qsize()
+        eap_queue_size = self.eap_output_queue.qsize()
+
+        message = RadiusAccessReject(1, 1, [])
+        self.sm.event(EventRadiusMessageReceived(message, None, []))
+
+        self.assertEqual(self.radius_output_queue.qsize(), rad_queue_size)
+        self.assertEqual(self.eap_output_queue.qsize(), eap_queue_size)
+
+    def test_smoke_test_send_request(self):
+        self.sm.port_enabled = True
+
+        self.receive_eth_packet()
+        radius_output = self.radius_output_queue.get_nowait()
+        self.assertEqual(self.sm.AAA_IDLE, self.sm.state)
+        self.assertEqual(radius_output[0], str(self.src_mac))
+
+    def test_smoke_test_success_radius(self):
+        self.sm.port_enabled = True
+        self.receive_eth_packet()
+
+        radius_output = self.radius_output_queue.get_nowait()
+        self.assertEqual(self.sm.AAA_IDLE, self.sm.state)
+        self.assertEqual(radius_output[0], str(self.src_mac))
+        # Receive Radius Accept
+        self.receive_radius_accept()
+        self.assertEqual(self.sm.AAA_SUCCESS, self.sm.state)
+
+    def test_smoke_test_fail_radius(self):
+        self.sm.port_enabled = True
+        self.receive_eth_packet()
+
+        radius_output = self.radius_output_queue.get_nowait()
+        self.assertEqual(self.sm.AAA_IDLE, self.sm.state)
+        self.assertEqual(radius_output[0], str(self.src_mac))
+        # Receive Radius Accept
+        self.receive_radius_reject()
+
+        self.assertEqual(self.sm.AAA_FAILURE, self.sm.state)

--- a/test/test_mab_state_machine.py
+++ b/test/test_mab_state_machine.py
@@ -1,42 +1,41 @@
 import logging
-from queue import Queue
 import tempfile
 import unittest
+from queue import Queue
+
+from chewie.ethernet_packet import EthernetPacket
 from chewie.event import EventMessageReceived, EventRadiusMessageReceived
 from chewie.mac_address import MacAddress
-from chewie.ethernet_packet import EthernetPacket
-from chewie.state_machines.mab_state_machine import MacAuthenticationBypassStateMachine
 from chewie.radius import RadiusAccessReject, RadiusAccessAccept
+from chewie.state_machines.mab_state_machine import MacAuthenticationBypassStateMachine
 
 
 # TODO Remove and create a 'test state machine' class
 def check_counters(_func=None, *,
-                   expected_auth_counter=0, expected_failure_counter=0, expected_logoff_counter=0):
+                   expected_auth_counter=0, expected_failure_counter=0):
     """Decorator to check the handlers have been called the
      correct number of times at the end of each test"""
+
     def decorator_check_counters(func):
         def wrapper(self):
-
             start_auth_counter = self.auth_counter
             start_failure_counter = self.failure_counter
-            start_logoff_counter = self.logoff_counter
             ret = func(self)
             self.assertEqual(self.auth_counter,
                              start_auth_counter + expected_auth_counter)
             self.assertEqual(self.failure_counter,
                              start_failure_counter + expected_failure_counter)
-            self.assertEqual(self.logoff_counter,
-                             start_logoff_counter + expected_logoff_counter)
             return ret
 
         return wrapper
+
     if _func is None:
         return decorator_check_counters
     else:
         return decorator_check_counters(_func)
 
-class MABStateMachineTest(unittest.TestCase):
 
+class MABStateMachineTest(unittest.TestCase):
     PORT_ID_MAC = MacAddress.from_string("00:00:00:00:00:01")
 
     def setUp(self):
@@ -46,30 +45,21 @@ class MABStateMachineTest(unittest.TestCase):
         self.log_file = tempfile.NamedTemporaryFile()
         logger.addHandler(logging.FileHandler(self.log_file.name))
 
-        self.eap_output_queue = Queue()
         self.radius_output_queue = Queue()
-        # TODO reset
         self.timer_scheduler = None
         self.src_mac = MacAddress.from_string("00:12:34:56:78:90")
         log_prefix = "chewie.SM - port: %s, client: %s" % (self.src_mac, self.PORT_ID_MAC)
 
-        self.sm = MacAuthenticationBypassStateMachine(self.eap_output_queue, self.radius_output_queue,
-                                                      self.src_mac,
-                                                      self.timer_scheduler, self.auth_handler, self.failure_handler,
-                                                      self.logoff_handler,
+        self.sm = MacAuthenticationBypassStateMachine(self.radius_output_queue,
+                                                      self.src_mac, self.timer_scheduler,
+                                                      self.auth_handler, self.failure_handler,
                                                       log_prefix)
 
         self.auth_counter = 0
         self.failure_counter = 0
-        self.logoff_counter = 0
 
-
-    def tearDown(self):
-        with open(self.log_file.name) as log:
-            self.assertNotIn('aaaEapResp is true. but data is false. This should never happen',
-                             log.read())
-
-    def auth_handler(self, client_mac, port_id_mac, timer, vlan_name, filter_id):  # pylint: disable=unused-argument
+    # pylint: disable=unused-argument
+    def auth_handler(self, client_mac, port_id_mac, timer, *arg, **kwargs):
         self.auth_counter += 1
         print('Successful auth from MAC %s' % str(client_mac))
 
@@ -77,41 +67,29 @@ class MABStateMachineTest(unittest.TestCase):
         self.failure_counter += 1
         print('failure from MAC %s' % str(client_mac))
 
-    def logoff_handler(self, client_mac, port_id_mac):  # pylint: disable=unused-argument
-        self.logoff_counter += 1
-        print('logoff from MAC %s' % str(client_mac))
-
     def receive_eth_packet(self):
+        """Receive Ethernet Frame and send to State Machine"""
         rad_queue_size = self.radius_output_queue.qsize()
-        eap_queue_size = self.eap_output_queue.qsize()
-
         message = EthernetPacket(self.PORT_ID_MAC, str(self.src_mac), 0x888e, "")
         self.sm.event(EventMessageReceived(message, self.PORT_ID_MAC))
-
         self.assertEqual(self.radius_output_queue.qsize(), rad_queue_size + 1)
-        self.assertEqual(self.eap_output_queue.qsize(), eap_queue_size)
 
     def receive_radius_accept(self):
+        """Receive Radius AccessAccept Packet and send to State Machine"""
         rad_queue_size = self.radius_output_queue.qsize()
-        eap_queue_size = self.eap_output_queue.qsize()
-
         message = RadiusAccessAccept(1, 1, [])
         self.sm.event(EventRadiusMessageReceived(message, None, []))
-
         self.assertEqual(self.radius_output_queue.qsize(), rad_queue_size)
-        self.assertEqual(self.eap_output_queue.qsize(), eap_queue_size)
 
     def receive_radius_reject(self):
+        """Receive Radius AccessReject Packet and send to State Machine"""
         rad_queue_size = self.radius_output_queue.qsize()
-        eap_queue_size = self.eap_output_queue.qsize()
-
         message = RadiusAccessReject(1, 1, [])
         self.sm.event(EventRadiusMessageReceived(message, None, []))
-
         self.assertEqual(self.radius_output_queue.qsize(), rad_queue_size)
-        self.assertEqual(self.eap_output_queue.qsize(), eap_queue_size)
 
     def test_smoke_test_send_request(self):
+        """Smoke Test Send RADIUS MAB Request on Receiving DHCP Activity"""
         self.sm.port_enabled = True
 
         self.receive_eth_packet()
@@ -119,25 +97,28 @@ class MABStateMachineTest(unittest.TestCase):
         self.assertEqual(self.sm.AAA_IDLE, self.sm.state)
         self.assertEqual(radius_output[0], str(self.src_mac))
 
+    @check_counters(expected_auth_counter=1)
     def test_smoke_test_success_radius(self):
+        """Smoke Test successful RADIUS Request"""
         self.sm.port_enabled = True
         self.receive_eth_packet()
 
         radius_output = self.radius_output_queue.get_nowait()
         self.assertEqual(self.sm.AAA_IDLE, self.sm.state)
         self.assertEqual(radius_output[0], str(self.src_mac))
-        # Receive Radius Accept
+
         self.receive_radius_accept()
         self.assertEqual(self.sm.AAA_SUCCESS, self.sm.state)
 
+    @check_counters(expected_failure_counter=1)
     def test_smoke_test_fail_radius(self):
+        """Smoke Test incorrect details sent to RADIUS Server"""
         self.sm.port_enabled = True
         self.receive_eth_packet()
 
         radius_output = self.radius_output_queue.get_nowait()
         self.assertEqual(self.sm.AAA_IDLE, self.sm.state)
         self.assertEqual(radius_output[0], str(self.src_mac))
-        # Receive Radius Accept
-        self.receive_radius_reject()
 
+        self.receive_radius_reject()
         self.assertEqual(self.sm.AAA_FAILURE, self.sm.state)

--- a/test/test_mac_address.py
+++ b/test/test_mac_address.py
@@ -1,4 +1,3 @@
-
 # pylint: disable=missing-docstring
 
 import unittest

--- a/test/test_message_parser.py
+++ b/test/test_message_parser.py
@@ -12,7 +12,6 @@ from chewie.eap import Eap
 from chewie.radius_attributes import State, CalledStationId, NASPortType
 from chewie.utils import MessageParseError
 
-
 class MessageParserTestCase(unittest.TestCase):
     def test_identity_request_message_parses(self):  # pylint: disable=invalid-name
         packed_message = bytes.fromhex("0180c2000003001906eab88c888e010000050101000501000000")
@@ -332,3 +331,21 @@ class MessageParserTestCase(unittest.TestCase):
         self.assertRaises(MessageParseError,
                           MessageParser.eap_parse,
                           data, MacAddress.from_string("00:00:00:12:34:56"))
+
+
+    # TODO
+    # def test_radius_mab_packs_basic(self):
+    #     """without extra_attributes or nas-port"""
+    #
+    #     packed_message = bytes.fromhex("01630047c7835a254dc85f1e82ec0702956c6d09010e61616262636364646565666602128502bedd390c0020bf4a13966324d99c1e1361612d62622d63632d64642d65652d6666")  # pylint: disable=line-too-long
+    #
+    #     src_mac = MacAddress.from_string("aa:bb:cc:dd:ee:ff")
+    #     radius_packet_id = 99
+    #     request_authenticator = bytes.fromhex("c7835a254dc85f1e82ec0702956c6d09")
+    #     state = None
+    #     secret = "SECRET"
+    #
+    #     packed_radius = MessagePacker.radius_mab_pack(src_mac, radius_packet_id, request_authenticator, secret, None)
+    #     self.assertEqual(packed_message, packed_radius,
+    #                      "Did not match\nActual: {}\nExpected: {}".format(
+    #                          binascii.hexlify(packed_radius), binascii.hexlify(packed_message)))

--- a/test/test_message_parser.py
+++ b/test/test_message_parser.py
@@ -1,16 +1,17 @@
-
 # pylint: disable=missing-docstring
 import struct
 import unittest
+
+from chewie.eap import Eap
+from chewie.mac_address import MacAddress
+from chewie.message_parser import EapolStartMessage, EapolLogoffMessage, \
+    SuccessMessage, FailureMessage
 from chewie.message_parser import MessageParser, MessagePacker, IdentityMessage, \
     Md5ChallengeMessage, TtlsMessage, \
     LegacyNakMessage, TlsMessage, PeapMessage
-from chewie.message_parser import EapolStartMessage, EapolLogoffMessage,\
-    SuccessMessage, FailureMessage
-from chewie.mac_address import MacAddress
-from chewie.eap import Eap
 from chewie.radius_attributes import State, CalledStationId, NASPortType
 from chewie.utils import MessageParseError
+
 
 class MessageParserTestCase(unittest.TestCase):
     def test_identity_request_message_parses(self):  # pylint: disable=invalid-name
@@ -191,7 +192,8 @@ class MessageParserTestCase(unittest.TestCase):
                                                 "010000b2026900b20d0016030100a7010000a303038c8007fa4ffe8f11fbe62debce4a1385e70be51efe77b105d205d2dc9ae815a5000038c02cc030009fcca9cca8ccaac02bc02f009ec024c028006bc023c0270067c00ac0140039c009c0130033009d009c003d003c0035002f00ff01000042000b000403000102000a000a0008001d0017001900180016000000170000000d0020001e060106020603050105020503040104020403030103020303020102020203")  # pylint: disable=line-too-long
         message = TlsMessage(src_mac=MacAddress.from_string("44:44:44:44:44:44"),
                              message_id=105, code=Eap.RESPONSE,
-                             flags=0x00, extra_data=bytes.fromhex('16030100a7010000a303038c8007fa4ffe8f11fbe62debce4a1385e70be51efe77b105d205d2dc9ae815a5000038c02cc030009fcca9cca8ccaac02bc02f009ec024c028006bc023c0270067c00ac0140039c009c0130033009d009c003d003c0035002f00ff01000042000b000403000102000a000a0008001d0017001900180016000000170000000d0020001e060106020603050105020503040104020403030103020303020102020203'))  # pylint: disable=line-too-long
+                             flags=0x00, extra_data=bytes.fromhex(
+                '16030100a7010000a303038c8007fa4ffe8f11fbe62debce4a1385e70be51efe77b105d205d2dc9ae815a5000038c02cc030009fcca9cca8ccaac02bc02f009ec024c028006bc023c0270067c00ac0140039c009c0130033009d009c003d003c0035002f00ff01000042000b000403000102000a000a0008001d0017001900180016000000170000000d0020001e060106020603050105020503040104020403030103020303020102020203'))  # pylint: disable=line-too-long
         packed_message = MessagePacker.ethernet_pack(message,
                                                      MacAddress.from_string("44:44:44:44:44:44"),
                                                      MacAddress.from_string("00:00:00:11:11:01"))
@@ -212,12 +214,12 @@ class MessageParserTestCase(unittest.TestCase):
         message = PeapMessage(src_mac=MacAddress.from_string("44:44:44:44:44:44"),
                               message_id=105, code=Eap.RESPONSE,
                               flags=0x00,
-                              extra_data=bytes.fromhex('16030100a7010000a303038c8007fa4ffe8f11fbe62debce4a1385e70be51efe77b105d205d2dc9ae815a5000038c02cc030009fcca9cca8ccaac02bc02f009ec024c028006bc023c0270067c00ac0140039c009c0130033009d009c003d003c0035002f00ff01000042000b000403000102000a000a0008001d0017001900180016000000170000000d0020001e060106020603050105020503040104020403030103020303020102020203'))  # pylint: disable=line-too-long
+                              extra_data=bytes.fromhex(
+                                  '16030100a7010000a303038c8007fa4ffe8f11fbe62debce4a1385e70be51efe77b105d205d2dc9ae815a5000038c02cc030009fcca9cca8ccaac02bc02f009ec024c028006bc023c0270067c00ac0140039c009c0130033009d009c003d003c0035002f00ff01000042000b000403000102000a000a0008001d0017001900180016000000170000000d0020001e060106020603050105020503040104020403030103020303020102020203'))  # pylint: disable=line-too-long
         packed_message = MessagePacker.ethernet_pack(message,
                                                      MacAddress.from_string("44:44:44:44:44:44"),
                                                      MacAddress.from_string("00:00:00:11:11:01"))
         self.assertEqual(expected_packed_message, packed_message)
-
 
     def test_legacy_nak_message_parses(self):
         packed_message = bytes.fromhex("0180c2000003000000111101888e"
@@ -270,7 +272,8 @@ class MessageParserTestCase(unittest.TestCase):
 
     def test_radius_packs_with_nas_port(self):
 
-        packed_message = bytes.fromhex("01bf00610123456789abcdeffedcba9876543210010a62656e62757274741f1361613a62623a63633a64643a65653a66660506000002a14f18021500160410824788d693e2adac6ce15641418228cf50121139bd192c46fe6d2a937d9573311b70")  # pylint: disable=line-too-long
+        packed_message = bytes.fromhex(
+            "01bf00610123456789abcdeffedcba9876543210010a62656e62757274741f1361613a62623a63633a64643a65653a66660506000002a14f18021500160410824788d693e2adac6ce15641418228cf50121139bd192c46fe6d2a937d9573311b70")  # pylint: disable=line-too-long
 
         src_mac = MacAddress.from_string("aa:bb:cc:dd:ee:ff")
         username = "benburtt"
@@ -288,7 +291,8 @@ class MessageParserTestCase(unittest.TestCase):
     def test_radius_packs_basic(self):
         """without extra_attributes or nas-port"""
 
-        packed_message = bytes.fromhex("01bf005b0123456789abcdeffedcba9876543210010a62656e62757274741f1361613a62623a63633a64643a65653a66664f18021500160410824788d693e2adac6ce15641418228cf5012caadc1c7a3be07fe63fdf83a59ed18c2")  # pylint: disable=line-too-long
+        packed_message = bytes.fromhex(
+            "01bf005b0123456789abcdeffedcba9876543210010a62656e62757274741f1361613a62623a63633a64643a65653a66664f18021500160410824788d693e2adac6ce15641418228cf5012caadc1c7a3be07fe63fdf83a59ed18c2")  # pylint: disable=line-too-long
 
         src_mac = MacAddress.from_string("aa:bb:cc:dd:ee:ff")
         username = "benburtt"
@@ -302,7 +306,8 @@ class MessageParserTestCase(unittest.TestCase):
                                                   request_authenticator, state, secret)
         self.assertEqual(packed_message, packed_radius)
 
-    def test_unicode_decode_error_converts_to_message_parse_error(self):  # pylint: disable=invalid-name
+    def test_unicode_decode_error_converts_to_message_parse_error(
+            self):  # pylint: disable=invalid-name
         data = bytes.fromhex("0163bf130103bf1301")
         try:
             MessageParser.eap_parse(data, MacAddress.from_string("00:00:00:12:34:56"))
@@ -311,7 +316,8 @@ class MessageParserTestCase(unittest.TestCase):
             return
         self.fail()
 
-    def test_struct_unpack_error_converts_to_message_parse_error(self):  # pylint: disable=invalid-name
+    def test_struct_unpack_error_converts_to_message_parse_error(
+            self):  # pylint: disable=invalid-name
         data = bytes.fromhex("01001000")
         try:
             MessageParser.eap_parse(data, MacAddress.from_string("00:00:00:12:34:56"))
@@ -331,7 +337,6 @@ class MessageParserTestCase(unittest.TestCase):
         self.assertRaises(MessageParseError,
                           MessageParser.eap_parse,
                           data, MacAddress.from_string("00:00:00:12:34:56"))
-
 
     # TODO
     # def test_radius_mab_packs_basic(self):


### PR DESCRIPTION
Add RADIUS Attributes - User-Password, NAS-Filer-Rule and Test
Add State Machine for core-MAB Functionality: NOTE - Not Completed
Add tests for MAB State Machine
Move All EAP-StateMachine Decision Logic into .event() and out of Chewie.py
Retain RADIUS Packet details when dequeuing from received queue.
Stop Radius Packet Payload Inspection in Chewie.py adn move to EAP State Machine
Main Pipeline no longer assumes EAP is the only RADIUS payload received.