### PR TITLE
BUGFIX: Fix EAP Response to Preemptive Requests from Chewie

### DIFF
--- a/chewie/state_machines/eap_state_machine.py
+++ b/chewie/state_machines/eap_state_machine.py
@@ -740,7 +740,7 @@ class FullEAPStateMachine:
         # TODO remove and refactor code - Just placing here to separate main pipeline for internals of SM
         if (isinstance(event, EventPreemptiveEAPResponseMessageReceived)
                 and event.preemptive_eap_id != self.current_id):
-            self.logget.info("Resetting eap due to recieved response to preemtive request")
+            self.logger.info("Resetting eap due to received response to preemtive request")
             self.eap_restart = True
             self.override_current_id = event.preemptive_eap_id
 


### PR DESCRIPTION
Fix pipeline for Eap responses to Chewie Probes
Add test for EAP response to avoid future regression