### PR TITLE
Issue 77 -  Remove EAP Message Assumption for Concat Radius Datatype. 

### DIFF
--- a/chewie/radius.py
+++ b/chewie/radius.py
@@ -185,9 +185,9 @@ class RadiusPacket(Radius):
 
             radius_packet.authenticator = request_authenticator
 
-            original_ma = message_authenticator.data_type.bytes_data
+            original_ma = message_authenticator.bytes_data
             # Replace the Original Message Authenticator
-            message_authenticator.data_type.bytes_data = bytes.fromhex(
+            message_authenticator.bytes_data = bytes.fromhex(
                 "00000000000000000000000000000000")
 
             radius_packet.pack()
@@ -267,7 +267,7 @@ class RadiusAttributesList:
         for value, list_ in attributes_to_concat.items():
             concatenated_data = b""
             for d, i in list_:
-                concatenated_data += d.data_type.bytes_data
+                concatenated_data += d.bytes_data
             concatenated_attributes.append(tuple((ATTRIBUTE_TYPES[value].parse(concatenated_data),
                                                   i)))
         # Remove old Attributes that were concatenated.
@@ -370,5 +370,5 @@ class RadiusAttributesList:
     def to_dict(self):
         ret = {}
         for a in self.attributes:
-            ret[a.DESCRIPTION] = a.data_type.data()
+            ret[a.DESCRIPTION] = a.data()
         return ret

--- a/chewie/radius_attributes.py
+++ b/chewie/radius_attributes.py
@@ -300,6 +300,25 @@ class EAPMessage(Attribute):
         as Concat.pack() may return multiple packed AVP (each with their own length)"""
         return self._data_type.pack(self.TYPE)
 
+    # NOTE: Delayed imports are to avoid circular dependency chain.
+    # Should be refactored out when possible but will need to redesign the message_parser module.
+    @classmethod
+    def create(cls, data):
+        """Factory method.
+        Args:
+            data: object of python type (int, str, bytes, ...)
+        Returns:
+            Attribute subclass.
+        """
+        from chewie.message_parser import MessagePacker, EapMessage
+        if isinstance(data, EapMessage):
+            return cls(cls.DATA_TYPE(bytes_data=MessagePacker.eap_pack(data)[2]))  # pylint: disable=not-callable
+        else:
+            return super(EAPMessage, cls).create(data)
+
+    def data(self):
+        from chewie.message_parser import MessageParser
+        return MessageParser.eap_parse(self._data_type.data(), None)
 
 @register_attribute_type
 class MessageAuthenticator(Attribute):

--- a/chewie/radius_attributes.py
+++ b/chewie/radius_attributes.py
@@ -7,9 +7,7 @@ from hashlib import md5
 
 import math
 from chewie.radius_datatypes import Concat, Enum, Integer, String, Text, Vsa
-
 ATTRIBUTE_TYPES = {}
-
 
 # TODO Fix Class Docstrings
 
@@ -23,7 +21,7 @@ class Attribute():
     HEADER_SIZE = 1 + 1
 
     def __init__(self, data_type):
-        self.data_type = data_type
+        self._data_type = data_type
 
     @classmethod
     def create(cls, data):
@@ -53,7 +51,7 @@ class Attribute():
             packed attribute (including header) bytes
         """
         tl = struct.pack("!BB", self.TYPE, self.full_length())
-        v = self.data_type.pack(self.TYPE)
+        v = self._data_type.pack(self.TYPE)
         return tl + v
 
     def full_length(self):
@@ -61,7 +59,18 @@ class Attribute():
         Returns:
             length (including header).
         """
-        return self.data_type.full_length()
+        return self._data_type.full_length()
+
+    def data(self):
+        return self._data_type.data()
+
+    @property
+    def bytes_data(self):
+        return self._data_type.bytes_data
+
+    @bytes_data.setter
+    def bytes_data(self, value):
+        self._data_type.bytes_data = value
 
 
 def register_attribute_type(cls):
@@ -289,7 +298,7 @@ class EAPMessage(Attribute):
     def pack(self):
         """Concat types need to override AttributeType.pack().
         as Concat.pack() may return multiple packed AVP (each with their own length)"""
-        return self.data_type.pack(self.TYPE)
+        return self._data_type.pack(self.TYPE)
 
 
 @register_attribute_type

--- a/chewie/radius_datatypes.py
+++ b/chewie/radius_datatypes.py
@@ -1,7 +1,6 @@
 """Radius Attribute Datatypes"""
 import struct
 
-import chewie.message_parser
 import math
 from chewie.utils import MessageParseError
 
@@ -186,10 +185,7 @@ class Concat(DataType):
 
     def __init__(self, bytes_data=None, raw_data=None):
         if raw_data:
-            if isinstance(raw_data, chewie.message_parser.EapMessage):
-                bytes_data = chewie.message_parser.MessagePacker.eap_pack(raw_data)[2]
-            else:
-                bytes_data = bytes.fromhex(raw_data)
+            bytes_data = bytes.fromhex(raw_data)
             # self.is_valid_length(data)
         self.bytes_data = bytes_data
 
@@ -228,7 +224,7 @@ class Concat(DataType):
         return packed
 
     def data(self):
-        return chewie.message_parser.MessageParser.eap_parse(self.bytes_data, None)
+        return self.bytes_data
 
     def full_length(self):
         return self.AVP_HEADER_LEN * \

--- a/chewie/state_machines/eap_state_machine.py
+++ b/chewie/state_machines/eap_state_machine.py
@@ -724,7 +724,7 @@ class FullEAPStateMachine:
     def strip_eap_from_radius_packet(self, radius):
         """Build a EventRadiusMessageReceived from a radius message"""
         eap_msg_attribute = radius.attributes.find(radius_attributes.EAPMessage.DESCRIPTION)
-        eap_msg = eap_msg_attribute.data_type.data()
+        eap_msg = eap_msg_attribute.data()
         state = radius.attributes.find(radius_attributes.State.DESCRIPTION)
         self.logger.info("radius EAP: %s", eap_msg)
         return EventRadiusMessageReceived(eap_msg, state, radius.attributes.to_dict())

--- a/test/test_full_state_machine.py
+++ b/test/test_full_state_machine.py
@@ -132,7 +132,7 @@ class FullStateMachineStartTestCase(unittest.TestCase):
         Here we restart part way through another."""
         self.test_md5_challenge_request()
 
-        self.assertEqual(self.sm.radius_state_attribute.data_type.data(), b'random state')
+        self.assertEqual(self.sm.radius_state_attribute.data(), b'random state')
 
         self.test_eap_restart()
         self.assertIsNone(self.sm.radius_state_attribute)

--- a/test/test_radius.py
+++ b/test/test_radius.py
@@ -26,23 +26,23 @@ class RadiusTestCase(unittest.TestCase):
         self.assertEqual(binascii.hexlify(message.authenticator), b"982a0ba06d3557f0dbc8ba6e823822f1")
         msg_attr = message.attributes
         self.assertEqual(len(msg_attr.attributes), 10)
-        self.assertEqual(msg_attr.find(UserName.DESCRIPTION).data_type.data(), 'host1user')
-        self.assertEqual(msg_attr.find(CalledStationId.DESCRIPTION).data_type.data(),
+        self.assertEqual(msg_attr.find(UserName.DESCRIPTION).data(), 'host1user')
+        self.assertEqual(msg_attr.find(CalledStationId.DESCRIPTION).data(),
                          "44-44-44-44-44-44:")
-        self.assertEqual(msg_attr.find(NASPortType.DESCRIPTION).data_type.data(), 19)
-        self.assertEqual(msg_attr.find(ServiceType.DESCRIPTION).data_type.data(), 2)
-        self.assertEqual(msg_attr.find(ConnectInfo.DESCRIPTION).data_type.data(),
+        self.assertEqual(msg_attr.find(NASPortType.DESCRIPTION).data(), 19)
+        self.assertEqual(msg_attr.find(ServiceType.DESCRIPTION).data(), 2)
+        self.assertEqual(msg_attr.find(ConnectInfo.DESCRIPTION).data(),
                          "CONNECT 0Mbps 802.11b")
-        self.assertEqual(msg_attr.find(AcctSessionId.DESCRIPTION).data_type.data(),
+        self.assertEqual(msg_attr.find(AcctSessionId.DESCRIPTION).data(),
                          "C648004A9C905579")
-        self.assertEqual(msg_attr.find(FramedMTU.DESCRIPTION).data_type.data(), 1400)
-        eap_msg = msg_attr.find(EAPMessage.DESCRIPTION).data_type.data()
+        self.assertEqual(msg_attr.find(FramedMTU.DESCRIPTION).data(), 1400)
+        eap_msg = msg_attr.find(EAPMessage.DESCRIPTION).data()
         self.assertEqual(eap_msg.message_id, 1)
         self.assertEqual(eap_msg.code, 2)
         self.assertEqual(eap_msg.identity, "host1user")
 
         self.assertEqual(binascii.hexlify(
-            msg_attr.find(MessageAuthenticator.DESCRIPTION).data_type.data()),
+            msg_attr.find(MessageAuthenticator.DESCRIPTION).data()),
                          b"73f82750f6f261a95a7cc7d318b9f573")
 
     def test_radius_access_accept_parses(self):
@@ -55,13 +55,13 @@ class RadiusTestCase(unittest.TestCase):
         self.assertEqual(binascii.hexlify(message.authenticator), b"02970aff2ef0700780f70848e90d2410")
         msg_attr = message.attributes
         self.assertEqual(len(msg_attr.attributes), 4)
-        eap_msg = msg_attr.find(EAPMessage.DESCRIPTION).data_type.data()
+        eap_msg = msg_attr.find(EAPMessage.DESCRIPTION).data()
         self.assertEqual(eap_msg.message_id, 2)
         self.assertIsInstance(eap_msg, SuccessMessage)
         self.assertEqual(binascii.hexlify(msg_attr.find(
-            MessageAuthenticator.DESCRIPTION).data_type.data()),
+            MessageAuthenticator.DESCRIPTION).data()),
                          b"d7ec84e8864dd6cd00916c1d5a3cf41b")
-        self.assertEqual(msg_attr.find(UserName.DESCRIPTION).data_type.data(), 'host1user')
+        self.assertEqual(msg_attr.find(UserName.DESCRIPTION).data(), 'host1user')
 
     def test_radius_access_accept_packs(self):
         expected_packed_message = bytes.fromhex("02010046"
@@ -139,15 +139,15 @@ class RadiusTestCase(unittest.TestCase):
         self.assertEqual(binascii.hexlify(message.authenticator), b"56d9280d3e4fed327eb31cf1823f8c24")
         msg_attr = message.attributes
         self.assertEqual(len(msg_attr.attributes), 3)
-        eap_msg = msg_attr.find(EAPMessage.DESCRIPTION).data_type.data()
+        eap_msg = msg_attr.find(EAPMessage.DESCRIPTION).data()
         self.assertEqual(eap_msg.code, 1)
         self.assertEqual(eap_msg.message_id, 2)
         self.assertEqual(binascii.hexlify(eap_msg.challenge),
                          b"74d3db089b727d9cc5774599e4a32a29")
         self.assertEqual(binascii.hexlify(msg_attr.find(
-            MessageAuthenticator.DESCRIPTION).data_type.data()),
+            MessageAuthenticator.DESCRIPTION).data()),
                          b"ecc840b316217c851bd6708afb554b24")
-        self.assertEqual(binascii.hexlify(msg_attr.find(State.DESCRIPTION).data_type.data()),
+        self.assertEqual(binascii.hexlify(msg_attr.find(State.DESCRIPTION).data()),
                          b"19ddf6d119dff272fa2fe16c34990c7d")
 
     def test_radius_access_challenge_ttls_parses(self):
@@ -161,7 +161,7 @@ class RadiusTestCase(unittest.TestCase):
         self.assertEqual(binascii.hexlify(message.authenticator), b"54dbc73332c00c0347fc4b462d1811a7")
         msg_attr = message.attributes
         self.assertEqual(len(msg_attr.attributes), 3)
-        eap_msg = msg_attr.find(EAPMessage.DESCRIPTION).data_type.data()
+        eap_msg = msg_attr.find(EAPMessage.DESCRIPTION).data()
         self.assertEqual(eap_msg.code, 1)
         self.assertEqual(eap_msg.message_id, 106)
         self.assertEqual(eap_msg.flags, 0xc0)
@@ -170,9 +170,9 @@ class RadiusTestCase(unittest.TestCase):
                          b"856e5cd5eed2d10037c9bcce89fbdf927e4cc4f069863acbac4accee7e80f2105ad80d837fa50a931c5b41d03c993f5e338cfd8e69e23818360053501c34c08132ec3d6e14df89ff29c5cec5c7a87d48c4afdcf9d3f8290050be5b903ba6a2a5ce2eb79c922cae70869618c75923059f9a8d62144e8ecdaf0a9f02886afa0e73e3d68037ea9fdca2bdd0f0785e05f5ac88031010c105575dbb09eb4f307547622120ee384ab454376de8e14e0afea02f1211801b6c932324ef6dba7abf3f48f8e3e84716c40b59041ec936cb273d684b22aa1c9d24e10203010001a34f304d30130603551d25040c300a06082b0601050507030130360603551d1f042f"
                          b"302d302ba029a0278625687474703a2f2f7777772e6578616d706c652e636f6d2f6578616d706c655f63612e63726c300d06092a864886f70d01010b0500038201010054fdcdabdc3a153dc167d6b210d1b324ecfac0e3b8d385704463a7f8ebf46e2e6952f249f4436ec66760868860e5ed50b519ec14628179472c312f507bc9349971d21f8f2b7d6b329b02fab448bd90fd4ce4dfbc78f23a8c4eed74d5589f4c3bd11b552535b8ab8a1a6ab9d1dfda21f247a93354702c12fdde1113cb8dd0e46e2a3a94547c9871df2a88943751d8276dc43f7f6aed921f43f6a33f9beba804c3d2b5781d754abe36ba58461798be8585b8b2")
         self.assertEqual(binascii.hexlify(msg_attr.find(
-            MessageAuthenticator.DESCRIPTION).data_type.data()),
+            MessageAuthenticator.DESCRIPTION).data()),
                          b"26e219fc875fd78976eb2b9b475b1488")
-        self.assertEqual(binascii.hexlify(msg_attr.find(State.DESCRIPTION).data_type.data()),
+        self.assertEqual(binascii.hexlify(msg_attr.find(State.DESCRIPTION).data()),
                          b"c1591073c33305b4fa8bd26dd27eafd9")
 
     def test_radius_access_challenge_packs(self):


### PR DESCRIPTION
Restrict all access to Attribute.data_type
Make data_type private to the Attribute type
Remove EAP Message Assumption for Concat Radius Datatype. 