### PR TITLE
depends_on needs to be array for docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
             context: .
             dockerfile: Dockerfile.wpasupplicant
         image: 'chewie/wpasupplicant:latest'
-        depends_on: chewie
+        depends_on: [chewie]
         command: bash -c "wpa_supplicant -dd -c/tmp/wpasupplicant/wired-peap.conf -ieth0 -Dwired;"
         networks:
             wpasupplicant-net:


### PR DESCRIPTION
`docker-compose up --build
`
 returns the following error which can be fixed by a quick fix to the docker-compose.yaml file. Otherwise, docker won't build at all and throw an error.

![fix_yaml](https://user-images.githubusercontent.com/22568590/62337186-7ac82600-b488-11e9-94bf-580b97766957.png)
